### PR TITLE
Ps-118: introduce support for start detectors 

### DIFF
--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleStore.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleStore.java
@@ -23,14 +23,17 @@ import java.io.Serializable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.StartDetector;
+
 public class LifecycleStore implements Serializable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LifecycleStore.class);
     
     private static final long serialVersionUID = 1L;
     private final LifecycleHandler[] handlers;
+    private final StartDetector startDetector;
     
-    LifecycleStore(LifecycleHandler[] handlersParam) {
+    LifecycleStore(LifecycleHandler[] handlersParam, StartDetector startDetectorParam) {
         handlers = handlersParam;
         assert handlers.length == LifecycleHandlerType.values().length : "array too small";
         for(LifecycleHandlerType t : LifecycleHandlerType.values()) {
@@ -38,6 +41,7 @@ public class LifecycleStore implements Serializable {
             if(h == null) 
                 throw new IllegalStateException("not the correct lifecycle handler");
         }
+        startDetector = startDetectorParam;
     }
     
     public <T extends LifecycleHandler> T getHandler(LifecycleHandlerType t, Class<T> type) {
@@ -61,4 +65,8 @@ public class LifecycleStore implements Serializable {
             return null;
         }
     }
+
+	public StartDetector getStartDetector() {
+		return startDetector;
+	}
 }

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleStoreBuilder.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleStoreBuilder.java
@@ -18,12 +18,24 @@
 
 package de.uniulm.omi.cloudiator.lance.lifecycle;
 
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.StartDetector;
+
 public final class LifecycleStoreBuilder {
 
     private final LifecycleHandler[] handlers = new LifecycleHandler[LifecycleHandlerType.values().length];
+    private volatile StartDetector startDetector;
     
     public LifecycleStoreBuilder() {
         // empty!
+    }
+    
+    public synchronized LifecycleStoreBuilder setStartDetector(StartDetector start) {
+    	if(startDetector == null || startDetector == start) {
+    		startDetector = start;
+    	} else {
+    		throw new IllegalStateException("start detector has already been set.");
+    	}
+    	return this;
     }
     
     public LifecycleStoreBuilder setHandler(LifecycleHandler h, LifecycleHandlerType t) {
@@ -48,7 +60,10 @@ public final class LifecycleStoreBuilder {
                 handlers[t.ordinal()] = t.getDefaultImplementation();
             }
         }
-        return new LifecycleStore(handlers);
+        if(startDetector == null) {
+        	throw new NullPointerException("start detector cannot be null");
+        }
+        return new LifecycleStore(handlers, startDetector);
     }
     
 }

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/bash/BashBasedHandlerBuilder.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/bash/BashBasedHandlerBuilder.java
@@ -184,12 +184,14 @@ final class BashStartDetectorHandler implements StartDetector {
     @Override
     public DetectorState execute(ExecutionContext ec) {
         BashExecutionHelper.executeCommands(os, ec, commands);
-        ExecutionResult result = BashExecutionHelper.doExecuteCommand(false, "echo \"$STARTED\"", ec.getShell());
+        ExecutionResult result = BashExecutionHelper.doExecuteCommand(false, "echo -n \"$STARTED\"", ec.getShell());
         if(result.isSuccess()) {
-        	if("true".equals(result.getOutput())) {
+        	// return values for docker is:
+        	// \nfalse\n0\n
+        	if("true".equals(result.getOutput().trim())) {
         		return DetectorState.DETECTED;
         	}
-        	if("false".equals(result.getOutput())) {
+        	if("false".equals(result.getOutput().trim())) {
         		return DetectorState.NOT_DETECTED;
         	}
         } 

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/bash/BashBasedHandlerBuilder.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/bash/BashBasedHandlerBuilder.java
@@ -23,9 +23,12 @@ import java.util.List;
 
 import de.uniulm.omi.cloudiator.lance.container.spec.os.OperatingSystem;
 import de.uniulm.omi.cloudiator.lance.lifecycle.ExecutionContext;
+import de.uniulm.omi.cloudiator.lance.lifecycle.ExecutionResult;
 import de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleHandler;
 import de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleHandlerType;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.DetectorState;
 import de.uniulm.omi.cloudiator.lance.lifecycle.detector.PortUpdateHandler;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.StartDetector;
 import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.InstallHandler;
 import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.PostInstallHandler;
 import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.PreInstallHandler;
@@ -42,6 +45,10 @@ public final class BashBasedHandlerBuilder {
 
     public PortUpdateHandler buildPortUpdateHandler() {
         return new BashPortUpdateHandler(os, commands);
+    }
+    
+    public StartDetector buildStartDetector() {
+    	return new BashStartDetectorHandler(os, commands);
     }
     
     public LifecycleHandler build(LifecycleHandlerType type) {
@@ -159,5 +166,33 @@ final class BashPortUpdateHandler implements PortUpdateHandler {
     @Override
     public void execute(ExecutionContext ec) {
         BashExecutionHelper.executeCommands(os, ec, commands);
+    }
+}
+
+final class BashStartDetectorHandler implements StartDetector {
+
+    private static final long serialVersionUID = -7036692445701185053L;
+    
+    private final OperatingSystem os;
+    private final List<String[]> commands;
+    
+    BashStartDetectorHandler(OperatingSystem osParam, List<String[]> commandsParam) {
+        os = osParam;
+        commands = commandsParam;
+    }
+    
+    @Override
+    public DetectorState execute(ExecutionContext ec) {
+        BashExecutionHelper.executeCommands(os, ec, commands);
+        ExecutionResult result = BashExecutionHelper.doExecuteCommand(false, "echo \"$STARTED\"", ec.getShell());
+        if(result.isSuccess()) {
+        	if("true".equals(result.getOutput())) {
+        		return DetectorState.DETECTED;
+        	}
+        	if("false".equals(result.getOutput())) {
+        		return DetectorState.NOT_DETECTED;
+        	}
+        } 
+        return DetectorState.DETECTION_FAILED;
     }
 }

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/bash/BashExecutionHelper.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/bash/BashExecutionHelper.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import de.uniulm.omi.cloudiator.lance.container.spec.os.OperatingSystem;
 import de.uniulm.omi.cloudiator.lance.lifecycle.ExecutionContext;
+import de.uniulm.omi.cloudiator.lance.lifecycle.ExecutionResult;
 import de.uniulm.omi.cloudiator.lance.lifecycle.Shell;
 
 final class BashExecutionHelper {
@@ -42,12 +43,12 @@ final class BashExecutionHelper {
         return res;
     }
     
-    private static void doExecuteCommand(boolean blocking, String command, Shell shell) {
+    static ExecutionResult doExecuteCommand(boolean blocking, String command, Shell shell) {
+    	// TODO: evaluate return values of commands and throw exceptions //
         if(blocking) {
-            shell.executeBlockingCommand(command);
-        } else { 
-            shell.executeCommand(command); 
-        }
+            return shell.executeBlockingCommand(command);
+        } 
+        return shell.executeCommand(command); 
     }
     
     static void executeCommands(OperatingSystem osParam, ExecutionContext ec, List<String[]> commands) {

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/DefaultDetectorFactories.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/DefaultDetectorFactories.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014-2015 University of Ulm
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.  Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package de.uniulm.omi.cloudiator.lance.lifecycle.detector;
+
+import de.uniulm.omi.cloudiator.lance.deployment.Deployment;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.DetectorFactory;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.StartDetector;
+
+public final class DefaultDetectorFactories {
+    
+    public static final DetectorFactory<StartDetector> START_DETECTOR_FACTORY = new DetectorFactory<StartDetector>() {
+    	
+        @Override public final StartDetector getDefault() { 
+        	return DefaultDetectorHandlers.DEFAULT_START_DETECTOR; 
+        }
+
+        @Override
+        public StartDetector getDeploymentHandler(Deployment d) {
+            return new StartDetectorHandler(d);
+        } 
+    };
+    
+    private DefaultDetectorFactories() {
+        // no instances of this class //
+    }
+}

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/DefaultDetectorHandlers.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/DefaultDetectorHandlers.java
@@ -34,7 +34,9 @@ public final class DefaultDetectorHandlers {
     }
     
     public static final StartDetector DEFAULT_START_DETECTOR = new StartDetector() {
-    	
+
+		private static final long serialVersionUID = 1L;
+
 		@Override
 		public DetectorState execute(ExecutionContext ec) {
 			getLogger().info("DEFAULT StopHandler doing nothing");

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/DefaultDetectorHandlers.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/DefaultDetectorHandlers.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2014-2015 University of Ulm
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.  Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package de.uniulm.omi.cloudiator.lance.lifecycle.detector;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.uniulm.omi.cloudiator.lance.lifecycle.ExecutionContext;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.DetectorState;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.StartDetector;
+
+public final class DefaultDetectorHandlers {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultDetectorHandlers.class);
+    
+    static Logger getLogger() { 
+    	return LOGGER; 
+    }
+    
+    public static final StartDetector DEFAULT_START_DETECTOR = new StartDetector() {
+    	
+		@Override
+		public DetectorState execute(ExecutionContext ec) {
+			getLogger().info("DEFAULT StopHandler doing nothing");
+			return DetectorState.DETECTED;
+		}
+	};
+    
+    private DefaultDetectorHandlers() {
+        // no instances //
+    }
+}

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/Detector.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/Detector.java
@@ -1,5 +1,7 @@
 package de.uniulm.omi.cloudiator.lance.lifecycle.detector;
 
-public interface Detector {
+import java.io.Serializable;
+
+public interface Detector extends Serializable {
 
 }

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/Detector.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/Detector.java
@@ -1,0 +1,5 @@
+package de.uniulm.omi.cloudiator.lance.lifecycle.detector;
+
+public interface Detector {
+
+}

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/DetectorFactory.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/DetectorFactory.java
@@ -1,0 +1,10 @@
+package de.uniulm.omi.cloudiator.lance.lifecycle.detector;
+
+import de.uniulm.omi.cloudiator.lance.deployment.Deployment;
+
+public interface DetectorFactory<T extends Detector> {
+
+	T getDefault();
+	T getDeploymentHandler(Deployment d);
+	
+}

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/DetectorState.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/DetectorState.java
@@ -1,0 +1,8 @@
+package de.uniulm.omi.cloudiator.lance.lifecycle.detector;
+
+public enum DetectorState {
+	DETECTED,
+	NOT_DETECTED,
+	DETECTION_FAILED,
+	;
+}

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/StartDetector.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/StartDetector.java
@@ -18,15 +18,35 @@
 
 package de.uniulm.omi.cloudiator.lance.lifecycle.detector;
 
+import de.uniulm.omi.cloudiator.lance.deployment.Deployment;
 import de.uniulm.omi.cloudiator.lance.lifecycle.ExecutionContext;
+import de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleHandlerType;
 
 /**
  * may be used to notify USM that a started event is ready for use
  * 
  * @author Joerg Domaschka
  */
-public interface StartDetector {
+public interface StartDetector extends Detector {
 
 	DetectorState execute(ExecutionContext ec);
     // empty interface; methods not yet fixed //
+}
+
+
+final class StartDetectorHandler implements StartDetector {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Deployment d;
+    
+    StartDetectorHandler(Deployment deploymentParam) {
+        d = deploymentParam;
+    }
+
+    @Override
+    public DetectorState execute(ExecutionContext ec) {
+        d.execute(LifecycleHandlerType.INSTALL, ec);
+        return DetectorState.DETECTED;
+    }
 }

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/StartDetector.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/StartDetector.java
@@ -18,11 +18,15 @@
 
 package de.uniulm.omi.cloudiator.lance.lifecycle.detector;
 
+import de.uniulm.omi.cloudiator.lance.lifecycle.ExecutionContext;
+
 /**
  * may be used to notify USM that a started event is ready for use
  * 
  * @author Joerg Domaschka
  */
 public interface StartDetector {
+
+	DetectorState execute(ExecutionContext ec);
     // empty interface; methods not yet fixed //
 }

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/StopDetector.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/detector/StopDetector.java
@@ -24,6 +24,6 @@ package de.uniulm.omi.cloudiator.lance.lifecycle.detector;
  * 
  * @author Joerg Domaschka
  */
-public interface StopDetector {
+public interface StopDetector extends Detector {
  // empty interface; methods not yet fixed //
 }

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/handlers/DefaultFactories.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/handlers/DefaultFactories.java
@@ -20,6 +20,8 @@ package de.uniulm.omi.cloudiator.lance.lifecycle.handlers;
 
 import de.uniulm.omi.cloudiator.lance.deployment.Deployment;
 import de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleHandlerFactory;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.DetectorFactory;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.StartDetector;
 
 public final class DefaultFactories {
 

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/handlers/DefaultHandlers.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/handlers/DefaultHandlers.java
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.uniulm.omi.cloudiator.lance.lifecycle.ExecutionContext;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.DetectorState;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.StartDetector;
 
 public final class DefaultHandlers {
     
@@ -123,6 +125,15 @@ public final class DefaultHandlers {
             getLogger().info("DEFAULT StopHandler doing nothing");
         }
     };
+    
+    public static final StartDetector DEFAULT_START_DETECTOR = new StartDetector() {
+    	
+		@Override
+		public DetectorState execute(ExecutionContext ec) {
+			getLogger().info("DEFAULT StopHandler doing nothing");
+			return DetectorState.DETECTED;
+		}
+	};
     
     public static final VoidHandler DEFAULT_VOID_HANDLER = new VoidHandler(); 
     

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/container/port/DownstreamPortUpdater.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/container/port/DownstreamPortUpdater.java
@@ -50,34 +50,6 @@ final class DownstreamPortUpdater implements Runnable {
         controller = controllerParam;
     }
     
-    /*
-    @Deprecated
-    public void handleUpdate(OutPort port, PortDiff<?> diff) {
-        //FIXME: ensure that we are in running state 
-        // if(!controller.isRunning()) return;
-        
-        // updating is rather easy. step 1: we get the update handler 
-        // for this port from the deployable component and then either
-        // do nothing or restart the application 
-        try {
-            DockerShell dshell = client.getSideShell(myId);
-            flushEnvironmentVariables(dshell);
-            flushSinglePort(dshell, port, diff.getCurrentSinkSet());
-            shellFactory.installDockerShell(dshell);
-            PortUpdateHandler handler = port.getUpdateHandler();
-            controller.blockingUpdatePorts(handler);
-        } catch(DockerException de) {
-            logger.info("problem when accessing registry", de); 
-        } catch (RegistrationException e) {
-            logger.info("problem when accessing registry", e); 
-        } finally {
-            shellFactory.closeShell();
-        }
-        //FIXME: only *now* update the set in the OutPortState
-        System.out.println("update the set in the OutPortState => ..."); //.printStackTrace();
-      
-    }  */
-    
     private List<PortDiff<DownstreamAddress>> getUpdatedPortSet() throws RegistrationException {
     	synchronized(portUpdateLock) {
     		if(updateInProgress) {

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/plain/PlainContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/plain/PlainContainerLogic.java
@@ -40,6 +40,7 @@ import de.uniulm.omi.cloudiator.lance.lifecycle.HandlerType;
 import de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleActionInterceptor;
 import de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleHandlerType;
 import de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleStore;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.DetectorType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -182,5 +183,15 @@ public class PlainContainerLogic implements ContainerLogic, LifecycleActionInter
 	public void preprocessPortUpdate(PortDiff<DownstreamAddress> diff)
 			throws ContainerException {
 		LOGGER.error("preprocessPortUpdate is not implemented for plain container");
+	}
+
+	@Override
+	public void postprocessDetector(DetectorType type) {
+		LOGGER.error("postprocessDetector is not implemented for plain container");
+	}
+
+	@Override
+	public void preprocessDetector(DetectorType type) throws ContainerException {
+		LOGGER.error("preprocessDetector is not implemented for plain container");
 	}
 }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleActionInterceptor.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleActionInterceptor.java
@@ -22,6 +22,7 @@ import de.uniulm.omi.cloudiator.lance.lca.container.ComponentInstanceId;
 import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
 import de.uniulm.omi.cloudiator.lance.lca.container.port.DownstreamAddress;
 import de.uniulm.omi.cloudiator.lance.lca.container.port.PortDiff;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.DetectorType;
 
 public interface LifecycleActionInterceptor {
 
@@ -35,4 +36,7 @@ public interface LifecycleActionInterceptor {
 
 	void preprocessPortUpdate(PortDiff<DownstreamAddress> diff) throws ContainerException;
 
+	void postprocessDetector(DetectorType type);
+
+	void preprocessDetector(DetectorType type) throws ContainerException;
 }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleController.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleController.java
@@ -107,7 +107,7 @@ public final class LifecycleController {
         run(LifecycleHandlerType.PRE_START);    // moves to START and calls 'start handler'
         StartDetectorHandler.runStartDetector(interceptor, store.getStartDetector(), ec);
         // FIXME: establish periodic invocation of stop detector
-        getLogger().warn("TODO: run start detector");
+        getLogger().warn("TODO: periodically run stop detector");
         machine.transit(LifecycleHandlerType.START);        // moves to POST_START
     }
     

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleController.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleController.java
@@ -28,17 +28,8 @@ import de.uniulm.omi.cloudiator.lance.lca.container.port.DownstreamAddress;
 import de.uniulm.omi.cloudiator.lance.lca.container.port.PortDiff;
 import de.uniulm.omi.cloudiator.lance.lca.registry.RegistrationException;
 import de.uniulm.omi.cloudiator.lance.lifecycle.detector.PortUpdateHandler;
-import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.InitHandler;
-import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.InstallHandler;
-import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.PostInstallHandler;
-import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.PostStartHandler;
-import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.PreInstallHandler;
-import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.PreStartHandler;
-import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.StartHandler;
-import de.uniulm.omi.cloudiator.lance.util.state.StateMachine;
-import de.uniulm.omi.cloudiator.lance.util.state.StateMachineBuilder;
-import de.uniulm.omi.cloudiator.lance.util.state.TransitionAction;
 
+import de.uniulm.omi.cloudiator.lance.util.state.StateMachine;
 public final class LifecycleController {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(LifecycleController.class);
@@ -57,7 +48,7 @@ public final class LifecycleController {
             GlobalRegistryAccessor accessorParam, ExecutionContext ecParam) {
         store = storeParam;
         ec = ecParam;
-        machine = buildStateMachine();
+        machine = LifecycleControllerTransitions.buildStateMachine(store, ec);
         interceptor = interceptorParam; 
         accessor = accessorParam;
         
@@ -114,11 +105,14 @@ public final class LifecycleController {
     
     public synchronized void blockingStart() {
         run(LifecycleHandlerType.PRE_START);    // moves to START and calls 'start handler'
-        // FIXME: establish start detector
-        // machine.transit(LifecycleHandlerType.START);        // moves to POST_START
+        // FIXME: establish start detectors
+        getLogger().warn("TODO: run start detector");
+        // FIXME: establish stop detector
+        getLogger().warn("TODO: run start detector");
+        machine.transit(LifecycleHandlerType.START);        // moves to POST_START
     }
     
-    public synchronized void blockingUpdatePorts(OutPort port, PortUpdateHandler handler, PortDiff<DownstreamAddress> diff) throws ContainerException {
+    public synchronized void blockingUpdatePorts(@SuppressWarnings("unused") OutPort port, PortUpdateHandler handler, PortDiff<DownstreamAddress> diff) throws ContainerException {
 	    try {
 	    	interceptor.preprocessPortUpdate(diff);
 	    	LOGGER.warn("updating ports via port handler.");
@@ -132,72 +126,5 @@ public final class LifecycleController {
 		}
     }
 
-    private StateMachine<LifecycleHandlerType> buildStateMachine() {
-        return addInitTransition(
-                addInstallTransitions(
-                        addStartTransitions(
-                                new  StateMachineBuilder<>(LifecycleHandlerType.NEW).
-                                addAllState(LifecycleHandlerType.values())
-                    ))).build();
-    }
-    
-    private StateMachineBuilder<LifecycleHandlerType> addInitTransition(StateMachineBuilder<LifecycleHandlerType> b) {
-        return b.addSynchronousTransition(LifecycleHandlerType.NEW, LifecycleHandlerType.INIT,
-                new TransitionAction() {
-                    @Override public void transit(Object[] params) {
-                        InitHandler h = store.getHandler(LifecycleHandlerType.INIT, InitHandler.class);
-                        h.execute(ec);
-                    }
-                });
-    }
-    
-    private StateMachineBuilder<LifecycleHandlerType> addInstallTransitions(StateMachineBuilder<LifecycleHandlerType> b) {
-        return b.addSynchronousTransition(LifecycleHandlerType.INIT, LifecycleHandlerType.PRE_INSTALL,
-                new TransitionAction() {
-                    @Override public void transit(Object[] params) {
-                        PreInstallHandler h = store.getHandler(LifecycleHandlerType.PRE_INSTALL, PreInstallHandler.class);
-                        h.execute(ec);
-                    }
-                }).
-                addSynchronousTransition(LifecycleHandlerType.PRE_INSTALL, LifecycleHandlerType.INSTALL, 
-                    new TransitionAction() {
-                        @Override public void transit(Object[] params) {
-                            InstallHandler h = store.getHandler(LifecycleHandlerType.INSTALL, InstallHandler.class);
-                            h.execute(ec);
-                        }
-                }). 
-                addSynchronousTransition(LifecycleHandlerType.INSTALL, LifecycleHandlerType.POST_INSTALL, 
-                    new TransitionAction() {
-                        @Override public void transit(Object[] params) {
-                            PostInstallHandler h = store.getHandler(LifecycleHandlerType.POST_INSTALL, PostInstallHandler.class);
-                            h.execute(ec);
-                        }
-                });        
-    }
-    
-    private StateMachineBuilder<LifecycleHandlerType> addStartTransitions(StateMachineBuilder<LifecycleHandlerType> b) {
-        return b.addSynchronousTransition(LifecycleHandlerType.POST_INSTALL, LifecycleHandlerType.PRE_START, 
-                new TransitionAction() {
-                    @Override public void transit(Object[] params) {
-                            PreStartHandler h = store.getHandler(LifecycleHandlerType.PRE_START, PreStartHandler.class);
-                            h.execute(ec);
-                    }
-                }).
-                addSynchronousTransition(LifecycleHandlerType.PRE_START, LifecycleHandlerType.START,
-                    new TransitionAction() {
-                        @Override public void transit(Object[] params) {
-                            StartHandler h = store.getHandler(LifecycleHandlerType.START, StartHandler.class);
-                            h.execute(ec);
-                            // FIXME: run start detector and stop detector //
-                            getLogger().warn("WARNING: run start detector and stop detector");
-                        }
-                }). 
-                addSynchronousTransition(LifecycleHandlerType.START, LifecycleHandlerType.POST_START,
-                    new TransitionAction() {
-                        @Override public void transit(Object[] params) {
-                            PostStartHandler h = store.getHandler(LifecycleHandlerType.POST_START, PostStartHandler.class);
-                            h.execute(ec);
-                    }
-                });
-    }
+
 }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleControllerTransitions.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleControllerTransitions.java
@@ -1,0 +1,100 @@
+package de.uniulm.omi.cloudiator.lance.lifecycle;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.InitHandler;
+import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.InstallHandler;
+import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.PostInstallHandler;
+import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.PostStartHandler;
+import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.PreInstallHandler;
+import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.PreStartHandler;
+import de.uniulm.omi.cloudiator.lance.lifecycle.handlers.StartHandler;
+import de.uniulm.omi.cloudiator.lance.util.state.StateMachine;
+import de.uniulm.omi.cloudiator.lance.util.state.StateMachineBuilder;
+import de.uniulm.omi.cloudiator.lance.util.state.TransitionAction;
+
+public class LifecycleControllerTransitions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LifecycleControllerTransitions.class);
+
+    static Logger getLogger() { 
+    	return LOGGER; 
+    }
+    
+    final LifecycleStore store;
+    final ExecutionContext ec;
+    
+	private LifecycleControllerTransitions(LifecycleStore storeParam, ExecutionContext ecParam) {
+		store = storeParam;
+		ec = ecParam;
+	}
+	
+    static StateMachine<LifecycleHandlerType> buildStateMachine(LifecycleStore storeParam, ExecutionContext ecParam) {
+    	LifecycleControllerTransitions transitions = new LifecycleControllerTransitions(storeParam, ecParam);
+        return transitions.addInitTransition(
+        		transitions.addInstallTransitions(
+        				transitions.addStartTransitions(
+                                new  StateMachineBuilder<>(LifecycleHandlerType.NEW).
+                                addAllState(LifecycleHandlerType.values())
+                    ))).build();
+    }
+    
+    private StateMachineBuilder<LifecycleHandlerType> addInitTransition(StateMachineBuilder<LifecycleHandlerType> b) {
+        return b.addSynchronousTransition(LifecycleHandlerType.NEW, LifecycleHandlerType.INIT,
+                new TransitionAction() {
+                    @Override public void transit(Object[] params) {
+                        InitHandler h = store.getHandler(LifecycleHandlerType.INIT, InitHandler.class);
+                        h.execute(ec);
+                    }
+                });
+    }
+    
+    private StateMachineBuilder<LifecycleHandlerType> addInstallTransitions(StateMachineBuilder<LifecycleHandlerType> b) {
+        return b.addSynchronousTransition(LifecycleHandlerType.INIT, LifecycleHandlerType.PRE_INSTALL,
+                new TransitionAction() {
+                    @Override public void transit(Object[] params) {
+                        PreInstallHandler h = store.getHandler(LifecycleHandlerType.PRE_INSTALL, PreInstallHandler.class);
+                        h.execute(ec);
+                    }
+                }).
+                addSynchronousTransition(LifecycleHandlerType.PRE_INSTALL, LifecycleHandlerType.INSTALL, 
+                    new TransitionAction() {
+                        @Override public void transit(Object[] params) {
+                            InstallHandler h = store.getHandler(LifecycleHandlerType.INSTALL, InstallHandler.class);
+                            h.execute(ec);
+                        }
+                }). 
+                addSynchronousTransition(LifecycleHandlerType.INSTALL, LifecycleHandlerType.POST_INSTALL, 
+                    new TransitionAction() {
+                        @Override public void transit(Object[] params) {
+                            PostInstallHandler h = store.getHandler(LifecycleHandlerType.POST_INSTALL, PostInstallHandler.class);
+                            h.execute(ec);
+                        }
+                });        
+    }
+    
+    private StateMachineBuilder<LifecycleHandlerType> addStartTransitions(StateMachineBuilder<LifecycleHandlerType> b) {
+        return b.addSynchronousTransition(LifecycleHandlerType.POST_INSTALL, LifecycleHandlerType.PRE_START, 
+                new TransitionAction() {
+                    @Override public void transit(Object[] params) {
+                            PreStartHandler h = store.getHandler(LifecycleHandlerType.PRE_START, PreStartHandler.class);
+                            h.execute(ec);
+                    }
+                }).
+                addSynchronousTransition(LifecycleHandlerType.PRE_START, LifecycleHandlerType.START,
+                    new TransitionAction() {
+                        @Override public void transit(Object[] params) {
+                            StartHandler h = store.getHandler(LifecycleHandlerType.START, StartHandler.class);
+                            h.execute(ec);
+                        }
+                }). 
+                addSynchronousTransition(LifecycleHandlerType.START, LifecycleHandlerType.POST_START,
+                    new TransitionAction() {
+                        @Override public void transit(Object[] params) {
+                            PostStartHandler h = store.getHandler(LifecycleHandlerType.POST_START, PostStartHandler.class);
+                            h.execute(ec);
+                    }
+                });
+    }
+}

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleException.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/LifecycleException.java
@@ -1,0 +1,22 @@
+package de.uniulm.omi.cloudiator.lance.lifecycle;
+
+public class LifecycleException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	public LifecycleException() {
+		super();
+	}
+
+	public LifecycleException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public LifecycleException(String message) {
+		super(message);
+	}
+
+	public LifecycleException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/StartDetectorHandler.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/StartDetectorHandler.java
@@ -47,6 +47,7 @@ final class StartDetectorHandler {
 	    		default:
 	    			throw new IllegalStateException("state " + state + " not captured");
     		}
+		getLogger().info("container not ready, sleeping.");
     		sleep();
     	}
     	throw new LifecycleException("application would not start. abort to wait.");
@@ -64,10 +65,12 @@ final class StartDetectorHandler {
     private DetectorState runStartDetectorLoop() {
     	boolean preprocessed = false;
     	 try {
+		 getLogger().info("running start detector");
     		 interceptor.preprocessDetector(DetectorType.START);
     		 preprocessed = true;
     		 return detector.execute(ec);
     	 } catch (ContainerException ce) {
+		 getLogger().warn("detection failed with exception", ce);
  			return DetectorState.DETECTION_FAILED;
  		} finally {
 			if(preprocessed) {

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/StartDetectorHandler.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lifecycle/StartDetectorHandler.java
@@ -1,0 +1,84 @@
+package de.uniulm.omi.cloudiator.lance.lifecycle;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.DetectorState;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.DetectorType;
+import de.uniulm.omi.cloudiator.lance.lifecycle.detector.StartDetector;
+
+final class StartDetectorHandler {
+    
+	private static final Logger LOGGER = LoggerFactory.getLogger(StartDetectorHandler.class);
+	
+	/** waiting 5 minutes per default */
+	private static final int MAXIMUM_START_WAIT_TIME = 300000;
+	/** waiting 30 seconds per loop */
+	private static final int START_LOOP_WAIT_TIME = 30000;
+	
+	static Logger getLogger() { 
+        return LOGGER; 
+    }
+	
+	private final LifecycleActionInterceptor interceptor;
+	private final StartDetector detector;
+	private final ExecutionContext ec;
+	
+    static void runStartDetector(LifecycleActionInterceptor interceptor, StartDetector detector, ExecutionContext ec) throws LifecycleException {
+    	StartDetectorHandler handler = new  StartDetectorHandler(interceptor, detector, ec);
+    	handler.doRun();
+    }
+    
+    private void doRun() throws LifecycleException {
+    	final long maxEndTime = System.currentTimeMillis() + MAXIMUM_START_WAIT_TIME;
+    	while(true) {
+    		if(maxEndTime < System.currentTimeMillis()) {
+    			break;
+    		}
+    		DetectorState state = runStartDetectorLoop();
+    		switch(state){
+	    		case DETECTED: 
+	    			return;
+	    		case DETECTION_FAILED: 
+	    			throw new LifecycleException();
+	    		case NOT_DETECTED:
+	    			 break;
+	    		default:
+	    			throw new IllegalStateException("state " + state + " not captured");
+    		}
+    		sleep();
+    	}
+    	throw new LifecycleException("application would not start. abort to wait.");
+    }
+    
+    private static void sleep() {
+    	try {
+			Thread.sleep(START_LOOP_WAIT_TIME);
+		} catch(InterruptedException ie) {
+			//TODO: handle this.
+			getLogger().warn("interrupted exception", ie);
+		}
+    }
+    
+    private DetectorState runStartDetectorLoop() {
+    	boolean preprocessed = false;
+    	 try {
+    		 interceptor.preprocessDetector(DetectorType.START);
+    		 preprocessed = true;
+    		 return detector.execute(ec);
+    	 } catch (ContainerException ce) {
+ 			return DetectorState.DETECTION_FAILED;
+ 		} finally {
+			if(preprocessed) {
+		        interceptor.postprocessDetector(DetectorType.STOP);
+			}
+		}
+    }
+	
+	private StartDetectorHandler(LifecycleActionInterceptor interceptorP, StartDetector detectorP, ExecutionContext ecP) {
+		interceptor = interceptorP;
+		detector = detectorP;
+		ec = ecP;
+	}
+}


### PR DESCRIPTION
now, the system can use start detectors to block until the component instance has successfully been started. Only then, will the state of the container be set to START. At least for Docker-based deployments this is supported.

As it is difficult to figure out from the return value of a script whether the script failed or the start has not been completed yet, a different approach is chosen. The lance run time system expects the StartDetector to set the environment variable "STARTED" to a value "true" or "false". It will then check this variable to determine the state. A return value != 0 or "STARTED" not being set is interpreted as a failure of the start detector.

An example start detector for bash is shown here (started successfully if PID 1 belongs to a process called nmp). First, it checks the name of PID 1 in variable PROG. then it compares it with nmp and sets STARTED to true or false.

PROG=`ps --pid 1 -o comm -h` && if [ \"$PROG\" == \"npm\" ] ; then export STARTED=\"true\" ; else export STARTED=\"false\" ; fi


