### PR TITLE
removed the closing of the PlainContainerShell

### DIFF
--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/plain/PlainContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/plain/PlainContainerLogic.java
@@ -98,7 +98,7 @@ public class PlainContainerLogic implements ContainerLogic, LifecycleActionInter
     @Override
     public void completeInit() throws ContainerException {
 
-        this.plainShellFactory.closeShell();
+        //this.plainShellFactory.closeShell();
     }
 
     @Override
@@ -190,7 +190,7 @@ public class PlainContainerLogic implements ContainerLogic, LifecycleActionInter
 
     @Override
     public void postprocessPortUpdate(PortDiff<DownstreamAddress> diff) {
-        plainShellFactory.closeShell();
+        //plainShellFactory.closeShell();
     }
 
     @Override


### PR DESCRIPTION
should resolve the following Exception when calling the stop lifecycle action for a PlainContainer:
```
java.util.concurrent.ExecutionException: java.lang.IllegalStateException: plain shell not set
	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.util.concurrent.FutureTask.get(FutureTask.java:192)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateMachineState.waitForFuture(ErrorAwareStateMachineState.java:164)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateMachineState.access$000(ErrorAwareStateMachineState.java:17)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateMachineState$1.waitForTransitionEnd(ErrorAwareStateMachineState.java:112)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateMachineState.cleanTransitionExceptions(ErrorAwareStateMachineState.java:72)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateMachine.transit(ErrorAwareStateMachine.java:63)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateMachine.transit(ErrorAwareStateMachine.java:151)
	at de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleController.run(LifecycleController.java:101)
	at de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleController.blockingStop(LifecycleController.java:163)
	at de.uniulm.omi.cloudiator.lance.container.standard.ErrorAwareContainer.preDestroyAction(ErrorAwareContainer.java:203)
	at de.uniulm.omi.cloudiator.lance.container.standard.DestroyTransitionAction.transit(DestroyTransitionAction.java:24)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateTransition$TransitionRunner.run(ErrorAwareStateTransition.java:157)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateTransition.postprocessExecutionTrigger(ErrorAwareStateTransition.java:94)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateMachine.transit(ErrorAwareStateMachine.java:70)
	at de.uniulm.omi.cloudiator.lance.container.standard.ErrorAwareContainer.tearDown(ErrorAwareContainer.java:145)
	at de.uniulm.omi.cloudiator.lance.lca.LifecycleAgentImpl.stopComponentInstance(LifecycleAgentImpl.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:323)
	at sun.rmi.transport.Transport$1.run(Transport.java:200)
	at sun.rmi.transport.Transport$1.run(Transport.java:197)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.rmi.transport.Transport.serviceCall(Transport.java:196)
	at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:568)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:826)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$241(TCPTransport.java:683)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler$$Lambda$2/1546007234.run(Unknown Source)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:682)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalStateException: plain shell not set
	at de.uniulm.omi.cloudiator.lance.lca.containers.plain.PlainShellFactoryImpl.createShell(PlainShellFactoryImpl.java:43)
	at de.uniulm.omi.cloudiator.lance.lca.containers.plain.PlainShellFactoryImpl.createShell(PlainShellFactoryImpl.java:33)
	at de.uniulm.omi.cloudiator.lance.lifecycle.ExecutionContext.getShell(ExecutionContext.java:38)
	at de.uniulm.omi.cloudiator.lance.lifecycle.bash.BashExecutionHelper.executeBlockingCommands(BashExecutionHelper.java:68)
	at de.uniulm.omi.cloudiator.lance.lifecycle.bash.BashStopHandler.execute(BashBasedHandlerBuilder.java:170)
	at de.uniulm.omi.cloudiator.lance.lifecycle.DefaultLifecycleTransition.transit(DefaultLifecycleTransition.java:26)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateTransition$TransitionRunner.run(ErrorAwareStateTransition.java:157)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateTransition.postprocessExecutionTrigger(ErrorAwareStateTransition.java:94)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateMachine.transit(ErrorAwareStateMachine.java:70)
	at de.uniulm.omi.cloudiator.lance.util.state.ErrorAwareStateMachine.transit(ErrorAwareStateMachine.java:151)
	at de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleController.run(LifecycleController.java:101)
	at de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleController.blockingStop(LifecycleController.java:156)
	... 27 common frames omitted
```