### PR TITLE
Implementation of Logic to handle runtime diffs in Docker Application 

### DIFF
--- a/client/src/main/java/de/uniulm/omi/cloudiator/lance/client/LifecycleClient.java
+++ b/client/src/main/java/de/uniulm/omi/cloudiator/lance/client/LifecycleClient.java
@@ -37,7 +37,7 @@ package de.uniulm.omi.cloudiator.lance.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.CONTAINER_STATUS;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.CONTAINER_STATUS;
 
 import com.github.rholder.retry.RetryException;
 import com.github.rholder.retry.Retryer;
@@ -58,6 +58,7 @@ import de.uniulm.omi.cloudiator.lance.container.standard.ExternalContextParamete
 import de.uniulm.omi.cloudiator.lance.lca.DeploymentException;
 import de.uniulm.omi.cloudiator.lance.lca.LcaException;
 import de.uniulm.omi.cloudiator.lance.lca.LcaRegistry;
+import de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants;
 import de.uniulm.omi.cloudiator.lance.lca.LifecycleAgent;
 import de.uniulm.omi.cloudiator.lance.lca.container.ComponentInstanceId;
 import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
@@ -210,7 +211,8 @@ public final class LifecycleClient {
     try {
       currentRegistry.addComponent(params.getAppId(), params.getcId(), params.getName());
       currentRegistry.addComponentInstance(params.getAppId(), params.getcId(), params.getcInstId());
-      currentRegistry.addComponentProperty(params.getAppId(), params.getcId(), params.getcInstId(), CONTAINER_STATUS , params.getStatus().toString());
+      currentRegistry.addComponentProperty(params.getAppId(), params.getcId(), params.getcInstId(),
+          LcaRegistryConstants.regEntries.get(CONTAINER_STATUS) , params.getStatus().toString());
       //do I need to create a DeploymentContext for this and do setProperty instead?
 
       for (ExternalContextParameters.InPortContext inPortC : params.getInpContext()) {

--- a/client/src/test/de/uniulm/omi/cloudiator/lance/client/ClientDockerPullTest.java
+++ b/client/src/test/de/uniulm/omi/cloudiator/lance/client/ClientDockerPullTest.java
@@ -572,9 +572,20 @@ public class ClientDockerPullTest {
   @Test
   public void testMStopContainers() {
     try {
-      sleep(120000);
-      client.undeploy(zookId, false);
+      sleep(2000);
+      Thread t = new Thread(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            client.undeploy(zookId, false);
+          } catch (DeploymentException e) {
+            System.err.println("Exception during deployment!");
+          };
+        }
+      });
+      t.start();
       client.undeploy(zookId_lifecycle, false);
+      t.join();
     } catch (DeploymentException ex) {
       System.err.println("Exception during deployment!");
     } catch (InterruptedException ex) {

--- a/client/src/test/de/uniulm/omi/cloudiator/lance/client/ClientDockerPullTest.java
+++ b/client/src/test/de/uniulm/omi/cloudiator/lance/client/ClientDockerPullTest.java
@@ -538,8 +538,8 @@ public class ClientDockerPullTest {
   @Test
   public void testMStopContainers() {
     try {
-      client.undeploy(zookId, true);
-      client.undeploy(zookId_lifecycle, true);
+      client.undeploy(zookId, false);
+      client.undeploy(zookId_lifecycle, false);
     } catch (DeploymentException ex) {
       System.err.println("Exception during deployment!");
     }

--- a/client/src/test/de/uniulm/omi/cloudiator/lance/client/ClientDockerPullTest.java
+++ b/client/src/test/de/uniulm/omi/cloudiator/lance/client/ClientDockerPullTest.java
@@ -377,7 +377,7 @@ public class ClientDockerPullTest {
       Map<Option,List<String>> createOptionMap = new HashMap<>();
       createOptionMap.put(Option.ENVIRONMENT, Arrays.asList("foo=bar","john=doe"));
       if (isDynComp) {
-        createOptionMap.put(Option.ENVIRONMENT, Arrays.asList("foo=bar","john=doe,dynamicgroup=group1"));
+        createOptionMap.put(Option.ENVIRONMENT, Arrays.asList("foo=bar","john=doe","dynamicgroup=group1"));
       }
       if (isDynHandler) {
         createOptionMap.put(Option.ENVIRONMENT, Arrays.asList("foo=bar","john=doe","dynamichandler=group1","updatescript=/the/script.sh"));
@@ -572,10 +572,13 @@ public class ClientDockerPullTest {
   @Test
   public void testMStopContainers() {
     try {
+      sleep(120000);
       client.undeploy(zookId, false);
       client.undeploy(zookId_lifecycle, false);
     } catch (DeploymentException ex) {
       System.err.println("Exception during deployment!");
+    } catch (InterruptedException ex) {
+      System.err.println("Interrupted!");
     }
   }
 }

--- a/client/src/test/de/uniulm/omi/cloudiator/lance/client/ClientDockerPullTest.java
+++ b/client/src/test/de/uniulm/omi/cloudiator/lance/client/ClientDockerPullTest.java
@@ -125,12 +125,13 @@ public class ClientDockerPullTest {
       List<InportInfo> inInfs,
       List<OutportInfo> outInfs,
       String imageFolder,
-      String tag, boolean isRemote) {
+      String tag, boolean isRemote,
+      boolean isDynComp, boolean isDynHandler) {
     DockerComponent.Builder builder;
     if (isRemote) {
-      builder = new DockerComponent.Builder(buildEntireDockerCommands(), imageName_remote);
+      builder = new DockerComponent.Builder(buildEntireDockerCommands(isDynComp, isDynHandler), imageName_remote);
     } else {
-      builder = new DockerComponent.Builder(buildEntireDockerCommands(), imageName);
+      builder = new DockerComponent.Builder(buildEntireDockerCommands(isDynComp, isDynHandler), imageName);
     }
     builder.name(compName);
     builder.imageFolder(imageFolder);
@@ -162,9 +163,10 @@ public class ClientDockerPullTest {
       ComponentId id,
       List<InportInfo> inInfs,
       List<OutportInfo> outInfs,
-      String tag, boolean isRemote) {
+      String tag, boolean isRemote,
+    boolean isDynComp, boolean isDynHandler) {
 
-    return buildDockerComponentBuilder(client, compName, id, inInfs, outInfs, "", tag, isRemote);
+    return buildDockerComponentBuilder(client, compName, id, inInfs, outInfs, "", tag, isRemote, isDynComp, isDynHandler);
   }
 
   private DockerComponent buildDockerComponent(
@@ -173,9 +175,10 @@ public class ClientDockerPullTest {
       ComponentId id,
       List<InportInfo> inInfs,
       List<OutportInfo> outInfs,
-      String tag) {
+      String tag,
+      boolean isDynComp, boolean isDynHandler) {
 
-    DockerComponent.Builder builder = buildDockerComponentBuilder(client, compName, id, inInfs, outInfs, tag, false);
+    DockerComponent.Builder builder = buildDockerComponentBuilder(client, compName, id, inInfs, outInfs, tag, false, isDynComp, isDynHandler);
     DockerComponent comp = builder.build();
     return comp;
   }
@@ -183,7 +186,7 @@ public class ClientDockerPullTest {
   private RemoteDockerComponent buildRemoteDockerComponent( LifecycleClient client, String compName, ComponentId id, List<InportInfo> inInfs,
       List<OutportInfo> outInfs, String imageFolder, String tag, String hostName, int port, boolean useCredentials) {
 
-    DockerComponent.Builder dCompBuilder = buildDockerComponentBuilder(client, compName, id, inInfs, outInfs, imageFolder, tag, true);
+    DockerComponent.Builder dCompBuilder = buildDockerComponentBuilder(client, compName, id, inInfs, outInfs, imageFolder, tag, true, false, false);
     RemoteDockerComponent.DockerRegistry dReg = new RemoteDockerComponent.DockerRegistry(hostName, port, "xxxxx", "xxxxx", useCredentials);
     RemoteDockerComponent rDockerComp = new RemoteDockerComponent(dCompBuilder, dReg);
 
@@ -297,7 +300,7 @@ public class ClientDockerPullTest {
   public void testCZookCompDescriptions() {
     List<InportInfo> inInfs = getInPortInfos(zookeeperInternalInportName);
     List<OutportInfo> outInfs = getOutPortInfos(zookeeperOutportName);
-    buildDockerComponent( client, zookeeperComponent, zookeeperComponentId, inInfs, outInfs, "3.4.12");
+    buildDockerComponent( client, zookeeperComponent, zookeeperComponentId, inInfs, outInfs, "3.4.12", true, false);
   }
 
   @Test
@@ -367,12 +370,18 @@ public class ClientDockerPullTest {
     return zookeeper_context;
   }
 
-  EntireDockerCommands buildEntireDockerCommands() {
+  EntireDockerCommands buildEntireDockerCommands(boolean isDynComp, boolean isDynHandler) {
     Random rand = new Random();
     EntireDockerCommands.Builder cmdsBuilder = new EntireDockerCommands.Builder();
     try {
       Map<Option,List<String>> createOptionMap = new HashMap<>();
       createOptionMap.put(Option.ENVIRONMENT, Arrays.asList("foo=bar","john=doe"));
+      if (isDynComp) {
+        createOptionMap.put(Option.ENVIRONMENT, Arrays.asList("foo=bar","john=doe,dynamicgroup=group1"));
+      }
+      if (isDynHandler) {
+        createOptionMap.put(Option.ENVIRONMENT, Arrays.asList("foo=bar","john=doe","dynamichandler=group1","updatescript=/the/script.sh"));
+      }
       String  n = Integer.toString(rand.nextInt(65536) + 1);
       createOptionMap.put(Option.PORT, new ArrayList<>(Arrays.asList(n)));
       createOptionMap.put(Option.RESTART, new ArrayList<>(Arrays.asList("no")));
@@ -478,8 +487,8 @@ public class ClientDockerPullTest {
     try {
       List<InportInfo> inInfs = getInPortInfos(zookeeperInternalInportName);
       List<OutportInfo> outInfs = getOutPortInfos(zookeeperOutportName);
-      DockerComponent zookComp = buildDockerComponent( client, zookeeperComponent, zookeeperComponentId, inInfs, outInfs, "3.4.12");
-      DeploymentContext zookContext = createZookeperContext(client, zookeeperComponentId_lifecycle, zookeeperInternalInportName_lifecycle, version.DOCKER );
+      DockerComponent zookComp = buildDockerComponent( client, zookeeperComponent, zookeeperComponentId, inInfs, outInfs, "3.4.12", true, false);
+      DeploymentContext zookContext = createZookeperContext(client, zookeeperComponentId, zookeeperInternalInportName, version.DOCKER );
       zookId =
           client.deploy(zookContext, zookComp);
       boolean isReady = false;
@@ -497,6 +506,7 @@ public class ClientDockerPullTest {
     System.out.println("zook is ready");
   }
 
+  @Ignore
   @Test
   public void testIZookDeploy_lifecycle() {
     try {
@@ -514,6 +524,30 @@ public class ClientDockerPullTest {
     } catch (DeploymentException ex) {
       System.err.println("Couldn't deploy lifecycle component");
     }
+  }
+
+  @Test
+  public void testIZookDeploy_latest() {
+    try {
+      List<InportInfo> inInfs = getInPortInfos(zookeeperInternalInportName_lifecycle);
+      List<OutportInfo> outInfs = getOutPortInfos(zookeeperOutportName_lifecycle);
+      DockerComponent zookComp = buildDockerComponent( client, zookeeperComponent_lifecycle, zookeeperComponentId_lifecycle, inInfs, outInfs, "latest", false, true);
+      DeploymentContext zookContext = createZookeperContext(client, zookeeperComponentId_lifecycle, zookeeperInternalInportName_lifecycle, version.LIFECYCLE );
+      zookId_lifecycle =
+          client.deploy(zookContext, zookComp);
+      boolean isReady = false;
+      do {
+        System.out.println("zook latest not ready");
+        isReady = client.isReady(zookId_lifecycle);
+        sleep(50);
+      } while (isReady != true);
+    } catch (DeploymentException ex) {
+      System.err.println("Couldn't deploy docker zookeeper component");
+    } catch (InterruptedException ex) {
+      System.err.println("Interrupted!");
+    }
+
+    System.out.println("zook latest is ready");
   }
 
   @Test

--- a/client/src/test/de/uniulm/omi/cloudiator/lance/client/ClientDockerPullTest.java
+++ b/client/src/test/de/uniulm/omi/cloudiator/lance/client/ClientDockerPullTest.java
@@ -572,7 +572,7 @@ public class ClientDockerPullTest {
   @Test
   public void testMStopContainers() {
     try {
-      sleep(120000);
+      sleep(2000);
       Thread t = new Thread(new Runnable() {
         @Override
         public void run() {
@@ -584,6 +584,7 @@ public class ClientDockerPullTest {
         }
       });
       t.start();
+      sleep(10000);
       client.undeploy(zookId_lifecycle, false);
       t.join();
     } catch (DeploymentException ex) {

--- a/client/src/test/de/uniulm/omi/cloudiator/lance/client/ClientDockerPullTest.java
+++ b/client/src/test/de/uniulm/omi/cloudiator/lance/client/ClientDockerPullTest.java
@@ -572,7 +572,7 @@ public class ClientDockerPullTest {
   @Test
   public void testMStopContainers() {
     try {
-      sleep(2000);
+      sleep(120000);
       Thread t = new Thread(new Runnable() {
         @Override
         public void run() {

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/AbstractComponent.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/AbstractComponent.java
@@ -41,8 +41,6 @@ public abstract class AbstractComponent implements Serializable, DynamicEnvVars 
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractComponent.class);
     private static final long serialVersionUID = -8078692212700712671L;
-    public static final String dynGroupKey = "dynamicgroup";
-    public static final String dynHandlerKey = "dynamichandler";
 
 
     private final String name;

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/AbstractComponent.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/AbstractComponent.java
@@ -146,6 +146,10 @@ public abstract class AbstractComponent implements Serializable, DynamicEnvVars 
       this.currentEnvVarsDynamic = DynamicEnvVarsImpl.NETWORK_PORTS;
   }
 
+  abstract boolean isDynamicComponent();
+
+  abstract boolean isDynamicHandler();
+
   abstract static class Builder<T extends Builder<T>> {
       protected String nameParam;
       protected ComponentId myIdParam;

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/AbstractComponent.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/AbstractComponent.java
@@ -41,6 +41,9 @@ public abstract class AbstractComponent implements Serializable, DynamicEnvVars 
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractComponent.class);
     private static final long serialVersionUID = -8078692212700712671L;
+    public static final String dynGroupKey = "dynamicgroup";
+    public static final String dynHandlerKey = "dynamichandler";
+
 
     private final String name;
     private final ComponentId myId;
@@ -146,9 +149,13 @@ public abstract class AbstractComponent implements Serializable, DynamicEnvVars 
       this.currentEnvVarsDynamic = DynamicEnvVarsImpl.NETWORK_PORTS;
   }
 
-  abstract boolean isDynamicComponent();
+  abstract public boolean isDynamicComponent();
 
-  abstract boolean isDynamicHandler();
+  abstract public boolean isDynamicHandler();
+
+  abstract public String getDynamicGroup() throws ContainerException;
+
+  abstract public String getDynamicHandler() throws ContainerException;
 
   abstract static class Builder<T extends Builder<T>> {
       protected String nameParam;

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/DeployableComponent.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/DeployableComponent.java
@@ -11,7 +11,17 @@ import de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleStore;
 public class DeployableComponent extends AbstractComponent {
     private final LifecycleStore lifecycle;
 
-    public static class Builder extends AbstractComponent.Builder<Builder> {
+  @Override
+  public boolean isDynamicComponent() {
+    return false;
+  }
+
+  @Override
+  public boolean isDynamicHandler() {
+    return false;
+  }
+
+  public static class Builder extends AbstractComponent.Builder<Builder> {
       private volatile LifecycleStore lifecycle;
 
       public Builder(String name, ComponentId id) {

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/DeployableComponent.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/DeployableComponent.java
@@ -1,5 +1,6 @@
 package de.uniulm.omi.cloudiator.lance.application.component;
 
+import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
 import de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleStore;
 
 import java.io.Serializable;
@@ -19,6 +20,16 @@ public class DeployableComponent extends AbstractComponent {
   @Override
   public boolean isDynamicHandler() {
     return false;
+  }
+
+  @Override
+  public String getDynamicGroup() throws ContainerException {
+    throw new ContainerException("Deployable Component cannot be in a dynamic group");
+  }
+
+  @Override
+  public String getDynamicHandler() throws ContainerException {
+    throw new ContainerException("Deployable Component cannot be a dynamic group handler");
   }
 
   public static class Builder extends AbstractComponent.Builder<Builder> {

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/DockerComponent.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/DockerComponent.java
@@ -1,8 +1,11 @@
 package de.uniulm.omi.cloudiator.lance.application.component;
 
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.DYN_GROUP_KEY;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.DYN_HANDLER_KEY;
+
+import de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants;
 import de.uniulm.omi.cloudiator.lance.lca.container.ComponentInstanceId;
 import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
-import de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleStore;
 
 import de.uniulm.omi.cloudiator.lance.lifecycle.language.DockerCommand;
 import de.uniulm.omi.cloudiator.lance.lifecycle.language.DockerCommand.Option;
@@ -57,8 +60,8 @@ public class DockerComponent extends AbstractComponent {
       this.containerName = builder.containerNameParam;
 
     List<String> createEnv = builder.entireDockerCommandsParam.getCreate().getSetOptions().get(Option.ENVIRONMENT);
-    dynGroupVal = filterEnvVal(createEnv, dynGroupKey);
-    dynHandlerVal = filterEnvVal(createEnv, dynHandlerKey);
+    dynGroupVal = filterEnvVal(createEnv, LcaRegistryConstants.regEntries.get(DYN_GROUP_KEY));
+    dynHandlerVal = filterEnvVal(createEnv, LcaRegistryConstants.regEntries.get(DYN_HANDLER_KEY));
   }
 
   private static String filterEnvVal(List<String> envStrings, String envKey) {

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/DockerComponent.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/DockerComponent.java
@@ -1,6 +1,7 @@
 package de.uniulm.omi.cloudiator.lance.application.component;
 
 import de.uniulm.omi.cloudiator.lance.lca.container.ComponentInstanceId;
+import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
 import de.uniulm.omi.cloudiator.lance.lifecycle.LifecycleStore;
 
 import de.uniulm.omi.cloudiator.lance.lifecycle.language.DockerCommand;
@@ -20,9 +21,6 @@ public class DockerComponent extends AbstractComponent {
         HashMap<String, ? extends Serializable> propertyValuesParam) {
         super(nameParam, idParam, inPortsParam, outPortsParam, propertiesParam, propertyValuesParam);
     }*/
-
-  private final static String dynGroupKey = "dynamicgroup";
-  private final static String dynHandlerKey = "dynamichandler";
 
   private final EntireDockerCommands entireDockerCommands;
   private final String imageName;
@@ -200,17 +198,19 @@ public class DockerComponent extends AbstractComponent {
     return true;
   }
 
-  public String getDynamicGroup() {
+  public String getDynamicGroup() throws ContainerException {
     if (!isDynamicComponent()) {
-      LOGGER.error("Retrieving a Dynamic group String, which is not set");
+      throw new ContainerException(String.format(
+          "No dynamic group name set for Docker component %s.", containerName));
     }
 
     return dynGroupVal;
   }
 
-  public String getDynamicHandler() {
+  public String getDynamicHandler() throws ContainerException {
     if (!isDynamicHandler()) {
-      LOGGER.error("Retrieving a Dynamic handler String, which is not set");
+      throw new ContainerException(String.format(
+          "No dynamic group name associated with dynamic handler for Docker component %s.", containerName));
     }
 
     return dynHandlerVal;

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/DockerComponent.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/application/component/DockerComponent.java
@@ -24,6 +24,7 @@ public class DockerComponent extends AbstractComponent {
         HashMap<String, ? extends Serializable> propertyValuesParam) {
         super(nameParam, idParam, inPortsParam, outPortsParam, propertiesParam, propertyValuesParam);
     }*/
+  private final static String updateScriptKey = "updatescript";
 
   private final EntireDockerCommands entireDockerCommands;
   private final String imageName;
@@ -32,6 +33,7 @@ public class DockerComponent extends AbstractComponent {
   private final String digestSHA256;
   private final String dynGroupVal;
   private final String dynHandlerVal;
+  private final String updateScriptFilePath;
   private String containerName;
 
   public DockerComponent(Builder builder) {
@@ -62,6 +64,7 @@ public class DockerComponent extends AbstractComponent {
     List<String> createEnv = builder.entireDockerCommandsParam.getCreate().getSetOptions().get(Option.ENVIRONMENT);
     dynGroupVal = filterEnvVal(createEnv, LcaRegistryConstants.regEntries.get(DYN_GROUP_KEY));
     dynHandlerVal = filterEnvVal(createEnv, LcaRegistryConstants.regEntries.get(DYN_HANDLER_KEY));
+    updateScriptFilePath = filterEnvVal(createEnv, updateScriptKey);
   }
 
   private static String filterEnvVal(List<String> envStrings, String envKey) {
@@ -133,6 +136,10 @@ public class DockerComponent extends AbstractComponent {
     return entireDockerCommands.getContainerName(DockerCommand.Type.CREATE);
   }
 
+  public String getUpdateScriptFilePath() {
+    return updateScriptFilePath;
+  }
+
   private static String buildNameOptionFromId(ComponentInstanceId id) {
     return "dockering__"+ id.toString();
   }
@@ -201,6 +208,7 @@ public class DockerComponent extends AbstractComponent {
     return true;
   }
 
+  @Override
   public String getDynamicGroup() throws ContainerException {
     if (!isDynamicComponent()) {
       throw new ContainerException(String.format(
@@ -210,6 +218,7 @@ public class DockerComponent extends AbstractComponent {
     return dynGroupVal;
   }
 
+  @Override
   public String getDynamicHandler() throws ContainerException {
     if (!isDynamicHandler()) {
       throw new ContainerException(String.format(

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/LcaRegistry.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/LcaRegistry.java
@@ -18,7 +18,8 @@
 
 package de.uniulm.omi.cloudiator.lance.lca;
 
-import java.io.Serializable; 
+import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 
 import de.uniulm.omi.cloudiator.lance.application.ApplicationId;
@@ -40,14 +41,15 @@ public interface LcaRegistry extends Serializable {
      * in the registry.
      * @throws RegistrationException when a registration error occurs.
      */
-    public boolean addApplicationInstance(ApplicationInstanceId instId, ApplicationId appId, String name) throws RegistrationException;
-    public void addComponent(ApplicationInstanceId instId, ComponentId cid, String name) throws RegistrationException;
-    public void addComponentInstance(ApplicationInstanceId instId, ComponentId cid, ComponentInstanceId cinstId) throws RegistrationException;
+    boolean addApplicationInstance(ApplicationInstanceId instId, ApplicationId appId, String name) throws RegistrationException;
+    void addComponent(ApplicationInstanceId instId, ComponentId cid, String name) throws RegistrationException;
+    void addComponentInstance(ApplicationInstanceId instId, ComponentId cid, ComponentInstanceId cinstId) throws RegistrationException;
     void addComponentProperty(ApplicationInstanceId instId, ComponentId cid, ComponentInstanceId cinstId, String property, Object value) throws RegistrationException;
-    public Map<ComponentInstanceId, Map<String, String>> dumpComponent(ApplicationInstanceId instId, ComponentId compId) throws RegistrationException;
-    public String getComponentProperty(ApplicationInstanceId appInstId,
+    Map<ComponentInstanceId, Map<String, String>> dumpComponent(ApplicationInstanceId instId, ComponentId compId) throws RegistrationException;
+    List<Map<String, String>> dumpAllRegComponents(ApplicationInstanceId instId) throws RegistrationException;
+    String getComponentProperty(ApplicationInstanceId appInstId,
             ComponentId compId, ComponentInstanceId myId, String name) throws RegistrationException;
-    public boolean applicationInstanceExists(ApplicationInstanceId appInstId) throws RegistrationException;
+    boolean applicationInstanceExists(ApplicationInstanceId appInstId) throws RegistrationException;
     boolean applicationComponentExists(ApplicationInstanceId appInstId, ComponentId compId) throws RegistrationException;
     void deleteComponentInstance(ApplicationInstanceId instId, ComponentId cid, ComponentInstanceId cinstId) throws RegistrationException;
 }

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/LcaRegistry.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/LcaRegistry.java
@@ -45,8 +45,9 @@ public interface LcaRegistry extends Serializable {
     void addComponent(ApplicationInstanceId instId, ComponentId cid, String name) throws RegistrationException;
     void addComponentInstance(ApplicationInstanceId instId, ComponentId cid, ComponentInstanceId cinstId) throws RegistrationException;
     void addComponentProperty(ApplicationInstanceId instId, ComponentId cid, ComponentInstanceId cinstId, String property, Object value) throws RegistrationException;
+    void addComponentProperty(ApplicationInstanceId instId, ComponentInstanceId cinstId, String property, Object value) throws RegistrationException;
     Map<ComponentInstanceId, Map<String, String>> dumpComponent(ApplicationInstanceId instId, ComponentId compId) throws RegistrationException;
-    List<Map<String, String>> dumpAllRegComponents(ApplicationInstanceId instId) throws RegistrationException;
+    Map<ComponentInstanceId, Map<String, String>> dumpAllAppComponents(ApplicationInstanceId instId) throws RegistrationException;
     String getComponentProperty(ApplicationInstanceId appInstId,
             ComponentId compId, ComponentInstanceId myId, String name) throws RegistrationException;
     boolean applicationInstanceExists(ApplicationInstanceId appInstId) throws RegistrationException;

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/LcaRegistryConstants.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/LcaRegistryConstants.java
@@ -19,13 +19,16 @@
 package de.uniulm.omi.cloudiator.lance.lca;
 
 import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.CLOUD_IP;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.CLOUD_PORT;
 import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.COMPONENT_INSTANCE_STATUS;
 import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.CONTAINER_IP;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.CONTAINER_PORT;
 import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.CONTAINER_STATUS;
 import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.DYN_GROUP_KEY;
 import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.DYN_HANDLER_KEY;
 import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.INSTANCE_NR;
 import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.PUBLIC_IP;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.PUBLIC_PORT;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,7 +37,8 @@ import java.util.Map;
 public final class LcaRegistryConstants {
 
     public enum Identifiers { CONTAINER_STATUS, COMPONENT_INSTANCE_STATUS,
-    PUBLIC_IP, CLOUD_IP, CONTAINER_IP, DYN_GROUP_KEY, DYN_HANDLER_KEY, INSTANCE_NR};
+      PUBLIC_IP, CLOUD_IP, CONTAINER_IP, PUBLIC_PORT, CLOUD_PORT, CONTAINER_PORT,
+      DYN_GROUP_KEY, DYN_HANDLER_KEY, INSTANCE_NR};
 
     public static final Map<Identifiers, String> regEntries;
     static {
@@ -44,6 +48,9 @@ public final class LcaRegistryConstants {
       aMap.put(PUBLIC_IP, "HOST_PUBLIC_IP");
       aMap.put(CLOUD_IP, "HOST_CLOUD_IP");
       aMap.put(CONTAINER_IP, "HOST_CONTAINER_IP");
+      aMap.put(PUBLIC_PORT, "HOST_PUBLIC_PORT");
+      aMap.put(CLOUD_PORT, "HOST_CLOUD_PORT");
+      aMap.put(CONTAINER_PORT, "HOST_CONTAINER_PORT");
       aMap.put(DYN_GROUP_KEY, "dynamicgroup");
       aMap.put(DYN_HANDLER_KEY, "dynamichandler");
       aMap.put(INSTANCE_NR, "Instance_Number");

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/LcaRegistryConstants.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/LcaRegistryConstants.java
@@ -18,18 +18,42 @@
 
 package de.uniulm.omi.cloudiator.lance.lca;
 
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.CLOUD_IP;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.COMPONENT_INSTANCE_STATUS;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.CONTAINER_IP;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.CONTAINER_STATUS;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.DYN_GROUP_KEY;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.DYN_HANDLER_KEY;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.INSTANCE_NR;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.PUBLIC_IP;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public final class LcaRegistryConstants {
 
-    public static final String CONTAINER_STATUS = "Container_Status";
-    public static final String COMPONENT_INSTANCE_STATUS = "Component_Instance_Status";
-    public static final String HOST_PUBLIC_IP = "Host_Public_Ip";
-    public static final String CLOUD_PROVIDER_ID = "Cloud_Provider_Id";
+    public enum Identifiers { CONTAINER_STATUS, COMPONENT_INSTANCE_STATUS,
+    PUBLIC_IP, CLOUD_IP, CONTAINER_IP, DYN_GROUP_KEY, DYN_HANDLER_KEY, INSTANCE_NR};
+
+    public static final Map<Identifiers, String> regEntries;
+    static {
+      Map<Identifiers , String> aMap = new HashMap<>();
+      aMap.put(CONTAINER_STATUS, "Container_Status");
+      aMap.put(COMPONENT_INSTANCE_STATUS, "Component_Instance_Status");
+      aMap.put(PUBLIC_IP, "HOST_PUBLIC_IP");
+      aMap.put(CLOUD_IP, "HOST_CLOUD_IP");
+      aMap.put(CONTAINER_IP, "HOST_CONTAINER_IP");
+      aMap.put(DYN_GROUP_KEY, "dynamicgroup");
+      aMap.put(DYN_HANDLER_KEY, "dynamichandler");
+      aMap.put(INSTANCE_NR, "Instance_Number");
+      regEntries = Collections.unmodifiableMap(aMap);
+    }
+
+    /*public static final String CLOUD_PROVIDER_ID = "Cloud_Provider_Id";
     public static final String HOST_INTERNAL_IP = "Host_Internal_Ip";
-    public static final String LOCAL_IP = "Local_Ip";
-    public static final String INSTANCE_NR = "Instance_Number";
-    
-    
+    public static final String LOCAL_IP = "Local_Ip";*/
+
     private LcaRegistryConstants () {
         // 
     }

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/registry/etcd/EtcdRegistryImpl.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/registry/etcd/EtcdRegistryImpl.java
@@ -121,7 +121,7 @@ final class EtcdRegistryImpl implements LcaRegistry {
 
     @Override
     public Map<ComponentInstanceId, Map<String, String>> dumpComponent(ApplicationInstanceId instId, ComponentId compId) throws RegistrationException {
-        
+
         Map<ComponentInstanceId, Map<String, String>> retVal = null;
         String dirName = generateComponentDirectory(instId, compId);
         EtcdKeysResponse ccc = null;
@@ -148,7 +148,7 @@ final class EtcdRegistryImpl implements LcaRegistry {
     public List<Map<String, String>> dumpAllRegComponents(ApplicationInstanceId instId)
         throws RegistrationException {
 
-      List<Map<String, String>> retVal = null;
+      List<Map<String, String>> retVal = new ArrayList<>();
       String dirName = generateApplicationInstanceDirectory(instId);
       EtcdKeysResponse ccc = null;
       try {

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/registry/etcd/EtcdRegistryImpl.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/registry/etcd/EtcdRegistryImpl.java
@@ -307,7 +307,7 @@ final class EtcdRegistryImpl implements LcaRegistry {
         String[] split = node.key.split("/");
         int size = split.length;
         if(size == 4) { // component instance element //
-          final String key = split[2];
+          final String key = split[3];
           idSet.add(ComponentId.fromString(key));
         } else {
           throw new IllegalStateException("invalid directory structure for key");

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/registry/rmi/ComponentInstanceContainer.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/registry/rmi/ComponentInstanceContainer.java
@@ -18,6 +18,8 @@
 
 package de.uniulm.omi.cloudiator.lance.lca.registry.rmi;
 
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.INSTANCE_NR;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -88,7 +90,7 @@ final class ComponentInstanceContainer {
             throw new IllegalArgumentException("alread exists: " + cinstId);
         Map<String,Object> map = new HashMap<>();
         Integer i = Integer.valueOf(counter.incrementAndGet());
-        map.put(LcaRegistryConstants.INSTANCE_NR, i);
+        map.put(LcaRegistryConstants.regEntries.get(INSTANCE_NR), i);
         instances.put(cinstId, map);
         
         LOGGER.info("LcaRegistry: added component instance: " + this + "/" + cinstId);

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/registry/rmi/RmiWrapper.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/registry/rmi/RmiWrapper.java
@@ -19,6 +19,7 @@
 package de.uniulm.omi.cloudiator.lance.lca.registry.rmi;
 
 import java.rmi.RemoteException;
+import java.util.List;
 import java.util.Map;
 
 import de.uniulm.omi.cloudiator.lance.application.ApplicationId;
@@ -88,7 +89,13 @@ public final class RmiWrapper implements LcaRegistry {
         }
     }
 
-    @Override
+  @Override
+  public List<Map<String, String>> dumpAllRegComponents(ApplicationInstanceId instId)
+      throws RegistrationException {
+    throw new RegistrationException("operation not implemented.");
+  }
+
+  @Override
     public String getComponentProperty(ApplicationInstanceId appInstId, ComponentId compId, ComponentInstanceId myId, String name)
             throws RegistrationException {
          try { 

--- a/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/registry/rmi/RmiWrapper.java
+++ b/common/src/main/java/de/uniulm/omi/cloudiator/lance/lca/registry/rmi/RmiWrapper.java
@@ -79,7 +79,14 @@ public final class RmiWrapper implements LcaRegistry {
         }
     }
 
-    @Override
+  @Override
+  public void addComponentProperty(ApplicationInstanceId instId, ComponentInstanceId cinstId,
+      String property, Object value) throws RegistrationException {
+    //todo: implement, though this is legacy code
+    throw new RegistrationException("Overloaded addComponentProperty method not implemented in Rmi Registry.");
+  }
+
+  @Override
     public Map<ComponentInstanceId, Map<String, String>> dumpComponent(
             ApplicationInstanceId instId, ComponentId compId) throws RegistrationException {
         try { 
@@ -90,8 +97,8 @@ public final class RmiWrapper implements LcaRegistry {
     }
 
   @Override
-  public List<Map<String, String>> dumpAllRegComponents(ApplicationInstanceId instId)
-      throws RegistrationException {
+  public Map<ComponentInstanceId, Map<String, String>> dumpAllAppComponents(
+      ApplicationInstanceId instId) throws RegistrationException {
     throw new RegistrationException("operation not implemented.");
   }
 
@@ -127,5 +134,6 @@ public final class RmiWrapper implements LcaRegistry {
     public void deleteComponentInstance(ApplicationInstanceId instId, ComponentId cid,
         ComponentInstanceId cinstId) throws RegistrationException {
        //todo: implement, though this is legacy code
+      throw new RegistrationException("Delete Component Instance not implemented in Rmi Registry.");
     }
 }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/ContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/ContainerLogic.java
@@ -19,6 +19,7 @@
 package de.uniulm.omi.cloudiator.lance.container.standard;
 
 import de.uniulm.omi.cloudiator.lance.application.component.AbstractComponent;
+import de.uniulm.omi.cloudiator.lance.lca.GlobalRegistryAccessor;
 import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
 import de.uniulm.omi.cloudiator.lance.lca.container.environment.BashExportBasedVisitor;
 import de.uniulm.omi.cloudiator.lance.lca.container.environment.PowershellExportBasedVisitor;
@@ -66,4 +67,8 @@ public interface ContainerLogic {
     AbstractComponent getComponent();
 
     boolean isValidDynamicProperty(String key);
+
+    void doStartDynHandling(GlobalRegistryAccessor accessor) throws ContainerException;
+
+    void doStopDynHandling() throws ContainerException ;
 }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/ContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/ContainerLogic.java
@@ -38,6 +38,7 @@ public interface ContainerLogic {
     void doInit(LifecycleStore store) throws ContainerException;
     
     void preInit() throws ContainerException;
+
     void completeShutDown() throws ContainerException;
 
     /**
@@ -61,4 +62,8 @@ public interface ContainerLogic {
     String getLocalAddress() throws ContainerException;
 
     InportAccessor getPortMapper();
+
+    AbstractComponent getComponent();
+
+    boolean isValidDynamicProperty(String key);
 }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/DestroyTransitionAction.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/DestroyTransitionAction.java
@@ -36,6 +36,7 @@ final class DestroyTransitionAction implements TransitionAction {
       }
       theContainer.logic.preDestroy();
       waitForDynamicSynchonisation();
+      stopDynamicHandlerThread();
       theContainer.logic.doDestroy(forceShutdown, theContainer.shouldBeRemoved());
       theContainer.registerStatus(ContainerStatus.DESTROYED);
     } catch (ContainerException | RegistrationException ce) {
@@ -100,6 +101,20 @@ final class DestroyTransitionAction implements TransitionAction {
     ErrorAwareContainer.getLogger().error(String
         .format("Timeout in Dynamic Component Instance: %s, while waiting for Dynamic Handler Instance to synchronize"
             + "the DELETION State.", theContainer.containerId));
+  }
+
+  private void stopDynamicHandlerThread() {
+    AbstractComponent myComp = theContainer.logic.getComponent();
+    if(!myComp.isDynamicHandler()) {
+      return;
+    }
+
+    try {
+      theContainer.logic.doStopDynHandling();
+    } catch (ContainerException e) {
+      ErrorAwareContainer.getLogger().error(String
+          .format("Error in shutting down the worker thread of the Dynamic Handler: %s", theContainer.containerId));
+    }
   }
 
   static void create(ErrorAwareTransitionBuilder<ContainerStatus> transitionBuilder, ErrorAwareContainer<?> container) {

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/DestroyTransitionAction.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/DestroyTransitionAction.java
@@ -83,6 +83,9 @@ final class DestroyTransitionAction implements TransitionAction {
         if(cInstanceStatus.equals(LifecycleHandlerType.PRE_STOP.name())) {
           theContainer.registerKeyValPair(LcaRegistryConstants.regEntries.get(
               Identifiers.COMPONENT_INSTANCE_STATUS), LifecycleHandlerType.STOP.name());
+          ErrorAwareContainer.getLogger().info(String
+              .format("Syncing done: Setting Dynamic Component Instance %s Component_Status back "
+                      + "to its consistent state: %s", theContainer.containerId, LifecycleHandlerType.STOP.name()));
           return;
         }
 
@@ -93,7 +96,7 @@ final class DestroyTransitionAction implements TransitionAction {
                 .get(Identifiers.COMPONENT_INSTANCE_STATUS), theContainer.containerId) , e);
       } catch (InterruptedException e) {
         throw new RegistrationException(String
-            .format("Component Instance: %s got interrupted while waiting for its Component_Instance_Stateto get synchronized.",
+            .format("Component Instance: %s got interrupted while waiting for its Component_Instance_State to get synchronized.",
                 theContainer.containerId) , e);
       }
     }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/DestroyTransitionAction.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/DestroyTransitionAction.java
@@ -80,9 +80,9 @@ final class DestroyTransitionAction implements TransitionAction {
             Identifiers.COMPONENT_INSTANCE_STATUS);
 
         //Sync-point here
-        if(cInstanceStatus == LifecycleHandlerType.PRE_STOP.toString()) {
+        if(cInstanceStatus.equals(LifecycleHandlerType.PRE_STOP.name())) {
           theContainer.registerKeyValPair(LcaRegistryConstants.regEntries.get(
-              Identifiers.COMPONENT_INSTANCE_STATUS), LifecycleHandlerType.STOP.toString());
+              Identifiers.COMPONENT_INSTANCE_STATUS), LifecycleHandlerType.STOP.name());
           return;
         }
 

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/DestroyTransitionAction.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/DestroyTransitionAction.java
@@ -16,7 +16,7 @@ import de.uniulm.omi.cloudiator.lance.util.state.TransitionException;
 final class DestroyTransitionAction implements TransitionAction {
 
   private final static int synchronPollTime = 10;
-  private final static int synchronTimeOut = 2000;
+  private final static int synchronTimeOut = 10000;
   private final ErrorAwareContainer<?> theContainer;
 
   private DestroyTransitionAction(ErrorAwareContainer<?> container) {

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/ErrorAwareContainer.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/ErrorAwareContainer.java
@@ -85,7 +85,11 @@ public final class ErrorAwareContainer<T extends ContainerLogic> implements Cont
       isReady = false;
     }
 
-    @Override
+  public GlobalRegistryAccessor getAccessor() {
+    return accessor;
+  }
+
+  @Override
     public ComponentInstanceId getId() {
         return containerId;
     }
@@ -100,12 +104,12 @@ public final class ErrorAwareContainer<T extends ContainerLogic> implements Cont
       return shouldBeRemovedParam;
     }
 
-  @Override
-  public void setShouldBeRemoved(boolean shouldBeRemoved) {
-    this.shouldBeRemovedParam = shouldBeRemoved;
-  }
+    @Override
+    public void setShouldBeRemoved(boolean shouldBeRemoved) {
+      this.shouldBeRemovedParam = shouldBeRemoved;
+    }
 
-  @Override
+    @Override
     public void create() {
         stateMachine.transit(ContainerStatus.NEW, ContainerStatus.CREATED, new Object[]{});
     }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/ErrorAwareContainer.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/ErrorAwareContainer.java
@@ -19,6 +19,7 @@
 package de.uniulm.omi.cloudiator.lance.container.standard;
 
 import de.uniulm.omi.cloudiator.lance.application.component.AbstractComponent;
+import de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -199,6 +200,20 @@ public final class ErrorAwareContainer<T extends ContainerLogic> implements Cont
         }
     }
 
+    public String readValFromRegistry(LcaRegistryConstants.Identifiers identifier) throws ContainerConfigurationException {
+      String retVal = null;
+      try {
+        retVal = accessor.getComponentInstanceProperty(containerId, LcaRegistryConstants.regEntries.get(identifier));
+      } catch (RegistrationException e) {
+        throw new ContainerConfigurationException("Cannot delete container " + containerId + "out of registry");
+      }
+
+      if(retVal==null)
+        retVal = "";
+
+      return retVal;
+    }
+
     void setNetworking() throws ContainerException {
         String address = logic.getLocalAddress();
         try {
@@ -263,7 +278,7 @@ public final class ErrorAwareContainer<T extends ContainerLogic> implements Cont
     	throw new UnexpectedContainerStateException("unexpected state reached: " + stat, stateMachine.collectExceptions());
     }
 
-  public void registerKeyValPair(String key, String val) throws RegistrationException {
+    public void registerKeyValPair(String key, String val) throws RegistrationException {
       if(!logic.isValidDynamicProperty(key)) {
         throw new RegistrationException(String
             .format("Setting key %s in registry for Component Instance %s is not allowed.", key, containerId));

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/ErrorAwareContainer.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/ErrorAwareContainer.java
@@ -262,4 +262,13 @@ public final class ErrorAwareContainer<T extends ContainerLogic> implements Cont
     	}
     	throw new UnexpectedContainerStateException("unexpected state reached: " + stat, stateMachine.collectExceptions());
     }
+
+  public void registerKeyValPair(String key, String val) throws RegistrationException {
+      if(!logic.isValidDynamicProperty(key)) {
+        throw new RegistrationException(String
+            .format("Setting key %s in registry for Component Instance %s is not allowed.", key, containerId));
+      }
+
+    accessor.addLocalProperty(key, val);
+  }
 }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/ErrorAwareContainer.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/ErrorAwareContainer.java
@@ -288,6 +288,6 @@ public final class ErrorAwareContainer<T extends ContainerLogic> implements Cont
             .format("Setting key %s in registry for Component Instance %s is not allowed.", key, containerId));
       }
 
-    accessor.addLocalProperty(key, val);
-  }
+      accessor.addLocalProperty(key, val);
+    }
 }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/InitTransitionAction.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/InitTransitionAction.java
@@ -26,16 +26,20 @@ final class InitTransitionAction implements TransitionAction {
             theContainer.preInitAction();
             theContainer.postInitAction();
             theContainer.registerStatus(ContainerStatus.READY);
-            AbstractComponent myComp = theContainer.logic.getComponent();
-            if(myComp.isDynamicComponent()) {
-              theContainer.registerKeyValPair(myComp.dynGroupKey,myComp.getDynamicGroup());
-            }
+            resgisterDynamicProperties();
         } catch (ContainerException | LifecycleException | RegistrationException ce) {
         	ErrorAwareContainer.getLogger().error("could not initialise container;", ce); 
         }
     }
 
-	public static void create(ErrorAwareTransitionBuilder<ContainerStatus> transitionBuilder,
+  private void resgisterDynamicProperties() throws ContainerException, RegistrationException {
+    AbstractComponent myComp = theContainer.logic.getComponent();
+    if(myComp.isDynamicComponent()) {
+      theContainer.registerKeyValPair(myComp.dynGroupKey,myComp.getDynamicGroup());
+    }
+  }
+
+  public static void create(ErrorAwareTransitionBuilder<ContainerStatus> transitionBuilder,
 			ErrorAwareContainer<?> container) {
 		
 		InitTransitionAction action = new InitTransitionAction(container);

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/InitTransitionAction.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/InitTransitionAction.java
@@ -1,6 +1,9 @@
 package de.uniulm.omi.cloudiator.lance.container.standard;
 
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.DYN_GROUP_KEY;
+
 import de.uniulm.omi.cloudiator.lance.application.component.AbstractComponent;
+import de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants;
 import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
 import de.uniulm.omi.cloudiator.lance.lca.container.ContainerStatus;
 import de.uniulm.omi.cloudiator.lance.lca.registry.RegistrationException;
@@ -35,7 +38,7 @@ final class InitTransitionAction implements TransitionAction {
   private void resgisterDynamicProperties() throws ContainerException, RegistrationException {
     AbstractComponent myComp = theContainer.logic.getComponent();
     if(myComp.isDynamicComponent()) {
-      theContainer.registerKeyValPair(myComp.dynGroupKey,myComp.getDynamicGroup());
+      theContainer.registerKeyValPair(LcaRegistryConstants.regEntries.get(DYN_GROUP_KEY), myComp.getDynamicGroup());
     }
   }
 

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/InitTransitionAction.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/InitTransitionAction.java
@@ -1,6 +1,7 @@
 package de.uniulm.omi.cloudiator.lance.container.standard;
 
 import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.DYN_GROUP_KEY;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.DYN_HANDLER_KEY;
 
 import de.uniulm.omi.cloudiator.lance.application.component.AbstractComponent;
 import de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants;
@@ -29,17 +30,22 @@ final class InitTransitionAction implements TransitionAction {
             theContainer.preInitAction();
             theContainer.postInitAction();
             theContainer.registerStatus(ContainerStatus.READY);
-            resgisterDynamicProperties();
+            initializeDynamicProperties();
         } catch (ContainerException | LifecycleException | RegistrationException ce) {
         	ErrorAwareContainer.getLogger().error("could not initialise container;", ce); 
         }
     }
 
-  private void resgisterDynamicProperties() throws ContainerException, RegistrationException {
+  private void initializeDynamicProperties() throws ContainerException, RegistrationException {
     AbstractComponent myComp = theContainer.logic.getComponent();
     if(myComp.isDynamicComponent()) {
       theContainer.registerKeyValPair(LcaRegistryConstants.regEntries.get(DYN_GROUP_KEY), myComp.getDynamicGroup());
     }
+    if(myComp.isDynamicHandler()) {
+      theContainer.registerKeyValPair(LcaRegistryConstants.regEntries.get(DYN_HANDLER_KEY), myComp.getDynamicHandler());
+      theContainer.logic.doStartDynHandling(theContainer.getAccessor());
+    }
+
   }
 
   public static void create(ErrorAwareTransitionBuilder<ContainerStatus> transitionBuilder,

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/InitTransitionAction.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/container/standard/InitTransitionAction.java
@@ -1,5 +1,6 @@
 package de.uniulm.omi.cloudiator.lance.container.standard;
 
+import de.uniulm.omi.cloudiator.lance.application.component.AbstractComponent;
 import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
 import de.uniulm.omi.cloudiator.lance.lca.container.ContainerStatus;
 import de.uniulm.omi.cloudiator.lance.lca.registry.RegistrationException;
@@ -25,6 +26,10 @@ final class InitTransitionAction implements TransitionAction {
             theContainer.preInitAction();
             theContainer.postInitAction();
             theContainer.registerStatus(ContainerStatus.READY);
+            AbstractComponent myComp = theContainer.logic.getComponent();
+            if(myComp.isDynamicComponent()) {
+              theContainer.registerKeyValPair(myComp.dynGroupKey,myComp.getDynamicGroup());
+            }
         } catch (ContainerException | LifecycleException | RegistrationException ce) {
         	ErrorAwareContainer.getLogger().error("could not initialise container;", ce); 
         }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/GlobalRegistryAccessor.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/GlobalRegistryAccessor.java
@@ -90,7 +90,7 @@ public final class GlobalRegistryAccessor {
     public final void syncDynamicDestructionStatus(ComponentInstanceId cId) throws RegistrationException {
       final String statusKey = LcaRegistryConstants.regEntries.get(Identifiers.CONTAINER_STATUS);
       final LifecycleHandlerType statusType = LifecycleHandlerType.PRE_STOP;
-      addLocalProperty(statusKey, statusType.name());
+      reg.addComponentProperty(appInstId, cId, statusKey, statusType.name());
     }
 
     /*

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/GlobalRegistryAccessor.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/GlobalRegistryAccessor.java
@@ -204,9 +204,11 @@ public final class GlobalRegistryAccessor {
       List<Map<String,String>> retVal = new ArrayList<>();
       List<Map<String,String>> compDumps = reg.dumpAllRegComponents(appInstId);
       final String statusKey = LcaRegistryConstants.regEntries.get(CONTAINER_STATUS);
+      final String readyVal = ContainerStatus.READY.name();
 
       for(Map<String,String> dump: compDumps) {
-        if(dump.get(statusKey) == ContainerStatus.READY.toString()) {
+       final  String dumpVal = dump.get(statusKey);
+        if(dumpVal.equals(readyVal)) {
           retVal.add(dump);
         }
       }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/GlobalRegistryAccessor.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/GlobalRegistryAccessor.java
@@ -18,7 +18,8 @@
 
 package de.uniulm.omi.cloudiator.lance.lca;
 
-import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.*;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.COMPONENT_INSTANCE_STATUS;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.CONTAINER_STATUS;
 
 import java.util.Map;
 
@@ -54,21 +55,23 @@ public final class GlobalRegistryAccessor {
     
     public final void init(ComponentInstanceId myId) throws RegistrationException {
         reg.addComponentInstance(appInstId, compId, myId);
-        reg.addComponentProperty(appInstId, compId, myId, COMPONENT_INSTANCE_STATUS, LifecycleHandlerType.NEW.toString());
+        reg.addComponentProperty(appInstId, compId, myId, LcaRegistryConstants.regEntries.get(COMPONENT_INSTANCE_STATUS), LifecycleHandlerType.NEW.toString());
     }
     
     public final void updateInstanceState(ComponentInstanceId myId, LifecycleHandlerType type) throws RegistrationException {
-        reg.addComponentProperty(appInstId, compId, myId, COMPONENT_INSTANCE_STATUS, type.toString());
+        reg.addComponentProperty(appInstId, compId, myId, LcaRegistryConstants.regEntries.get(COMPONENT_INSTANCE_STATUS), type.toString());
     }
     
     public final void updateContainerState(ComponentInstanceId myId, ContainerStatus type) throws RegistrationException {
-        reg.addComponentProperty(appInstId, compId, myId, CONTAINER_STATUS, type.toString());
+        reg.addComponentProperty(appInstId, compId, myId, LcaRegistryConstants.regEntries.get(CONTAINER_STATUS), type.toString());
     }
     
     public static boolean dumpMapHasContainerStatus(Map<String, String> map, ContainerStatus type) {
     	if(type == null) 
     		throw new NullPointerException("type has to be set");
-    	return type.toString().equals(map.get(CONTAINER_STATUS));
+
+    	final String contStatus = LcaRegistryConstants.regEntries.get(CONTAINER_STATUS);
+    	return type.toString().equals(map.get(contStatus));
     }
 
     public final void deleteComponentInstance() throws RegistrationException {

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/GlobalRegistryAccessor.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/GlobalRegistryAccessor.java
@@ -21,6 +21,8 @@ package de.uniulm.omi.cloudiator.lance.lca;
 import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.COMPONENT_INSTANCE_STATUS;
 import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.CONTAINER_STATUS;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import de.uniulm.omi.cloudiator.lance.application.ApplicationInstanceId;
@@ -196,7 +198,22 @@ public final class GlobalRegistryAccessor {
     public Map<ComponentInstanceId, Map<String, String>> retrieveComponentDump(PortReference sinkReference) throws RegistrationException {
         return reg.dumpComponent(appInstId, sinkReference.getComponentId());
     }
-    
+
+
+    public List<Map<String,String>> getReadyDumps() throws RegistrationException {
+      List<Map<String,String>> retVal = new ArrayList<>();
+      List<Map<String,String>> compDumps = reg.dumpAllRegComponents(appInstId);
+      final String statusKey = LcaRegistryConstants.regEntries.get(CONTAINER_STATUS);
+
+      for(Map<String,String> dump: compDumps) {
+        if(dump.get(statusKey) == ContainerStatus.READY.toString()) {
+          retVal.add(dump);
+        }
+      }
+
+      return retVal;
+    }
+
     public void addLocalProperty(String key, String value) throws RegistrationException {
         reg.addComponentProperty(appInstId, compId, localId, key, value);
     }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/GlobalRegistryAccessor.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/GlobalRegistryAccessor.java
@@ -212,20 +212,28 @@ public final class GlobalRegistryAccessor {
         return reg.dumpComponent(appInstId, sinkReference.getComponentId());
     }
 
-
-    public Map<ComponentInstanceId, Map<String,String>> getReadyDumps() throws RegistrationException {
+    /* RUNNING == (READY && (START || POST_START)) */
+    public Map<ComponentInstanceId, Map<String,String>> getRunningDumps() throws RegistrationException {
       Map<ComponentInstanceId, Map<String,String>> retVal = new HashMap<>();
       Map<ComponentInstanceId, Map<String,String>> compDumps = reg.dumpAllAppComponents(appInstId);
-      final String statusKey = LcaRegistryConstants.regEntries.get(CONTAINER_STATUS);
+
+      final String contStatusKey = LcaRegistryConstants.regEntries.get(CONTAINER_STATUS);
+      final String instStatusKey = LcaRegistryConstants.regEntries.get(COMPONENT_INSTANCE_STATUS);
       final String readyVal = ContainerStatus.READY.name();
+      final String startVal = LifecycleHandlerType.START.name();
+      final String postStartVal = LifecycleHandlerType.POST_START.name();
 
       for(Map.Entry<ComponentInstanceId, Map<String,String>> dump: compDumps.entrySet()) {
-        if(dump.getValue() == null || dump.getValue().get(statusKey) == null) {
+        if(dump.getValue() == null || dump.getValue().get(contStatusKey) == null
+            || dump.getValue().get(instStatusKey) == null) {
           continue;
         }
+
         Map<String,String> dumpMap = dump.getValue();
-        final String dumpVal = dumpMap.get(statusKey);
-        if(dumpVal.equals(readyVal)) {
+        final String dumpCStatusVal = dumpMap.get(contStatusKey);
+        final String dumpIStatusVal = dumpMap.get(instStatusKey);
+        if(dumpCStatusVal.equals(readyVal) && (dumpIStatusVal.equals(startVal)
+          || dumpIStatusVal.equals(postStartVal))) {
           retVal.put(dump.getKey(),dump.getValue());
         }
       }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/GlobalRegistryAccessor.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/GlobalRegistryAccessor.java
@@ -84,11 +84,11 @@ public final class GlobalRegistryAccessor {
     }
 
     /* This method initializes the synchronisation between a Dynamic handler and a dynamic component.
-       The handler calls this method, which sets the Container_Status of the blocked dynamic component to
+       The handler calls this method, which sets the Instance_Status of the blocked dynamic component to
        PRE_STOP. This unblocks the Dynamic Component.
     */
     public final void syncDynamicDestructionStatus(ComponentInstanceId cId) throws RegistrationException {
-      final String statusKey = LcaRegistryConstants.regEntries.get(Identifiers.CONTAINER_STATUS);
+      final String statusKey = LcaRegistryConstants.regEntries.get(Identifiers.COMPONENT_INSTANCE_STATUS);
       final LifecycleHandlerType statusType = LifecycleHandlerType.PRE_STOP;
       reg.addComponentProperty(appInstId, cId, statusKey, statusType.name());
     }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/container/port/NetworkHandler.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/container/port/NetworkHandler.java
@@ -73,7 +73,11 @@ public final class NetworkHandler implements DynamicEnvVars {
         currentEnvVarsDynamic = new HashSet<>();
     }
 
-    //todo: exception handling if wrong enum type
+  public PortRegistryTranslator getPortAccessor() {
+    return portAccessor;
+  }
+
+  //todo: exception handling if wrong enum type
     public void injectDynamicEnvVars(DynamicEnvVarsImpl vars) throws ContainerException {
         this.currentEnvVarsDynamic.add(vars);
     }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/container/port/PortRegistryTranslator.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/container/port/PortRegistryTranslator.java
@@ -85,7 +85,11 @@ public final class PortRegistryTranslator {
         hostContext = context;
     }
 
-    public void registerLocalPortAtLevel(String portName, PortHierarchyLevel level, Integer value) throws RegistrationException {
+  public GlobalRegistryAccessor getAccessor() {
+    return accessor;
+  }
+
+  public void registerLocalPortAtLevel(String portName, PortHierarchyLevel level, Integer value) throws RegistrationException {
         String key = buildFullPortName(portName, level);
         accessor.addLocalProperty(key, value.toString());
     }
@@ -185,7 +189,7 @@ public final class PortRegistryTranslator {
         }
     }
     
-    private static String getHierarchicalHostname(PortHierarchyLevel level, Map<String, String> dump) throws RegistrationException {
+    public static String getHierarchicalHostname(PortHierarchyLevel level, Map<String, String> dump) throws RegistrationException {
         String key = buildFullHostName(level);
         String value = dump.get(key);
         if(value == null) {

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/AbstractDockerContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/AbstractDockerContainerLogic.java
@@ -268,6 +268,12 @@ abstract class AbstractDockerContainerLogic implements ContainerLogic, Lifecycle
 
   abstract void collectDynamicEnvVars();
 
+  @Override
+  public abstract AbstractComponent getComponent();
+
+  @Override
+  public abstract boolean isValidDynamicProperty(String key);
+
   abstract static class Builder<T extends AbstractComponent, S extends Builder<T,S>> {
     protected ComponentInstanceId myId;
     protected DockerConnector client;

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/AbstractDockerContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/AbstractDockerContainerLogic.java
@@ -23,6 +23,7 @@ import de.uniulm.omi.cloudiator.lance.application.component.AbstractComponent;
 import de.uniulm.omi.cloudiator.lance.application.component.InPort;
 import de.uniulm.omi.cloudiator.lance.container.spec.os.OperatingSystem;
 import de.uniulm.omi.cloudiator.lance.container.standard.ContainerLogic;
+import de.uniulm.omi.cloudiator.lance.lca.GlobalRegistryAccessor;
 import de.uniulm.omi.cloudiator.lance.lca.HostContext;
 import de.uniulm.omi.cloudiator.lance.lca.container.environment.StaticEnvVars;
 import de.uniulm.omi.cloudiator.lance.lca.container.ComponentInstanceId;
@@ -273,6 +274,12 @@ abstract class AbstractDockerContainerLogic implements ContainerLogic, Lifecycle
 
   @Override
   public abstract boolean isValidDynamicProperty(String key);
+
+  @Override
+  public abstract void doStartDynHandling(GlobalRegistryAccessor accessor) throws ContainerException;
+
+  @Override
+  public abstract void doStopDynHandling() throws ContainerException ;
 
   abstract static class Builder<T extends AbstractComponent, S extends Builder<T,S>> {
     protected ComponentInstanceId myId;

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerContainerLogic.java
@@ -56,7 +56,7 @@ public class DockerContainerLogic extends AbstractDockerContainerLogic {
     //Getting initialized dynamically
     dynHandler = null;
     //todo: check if must be initialised in doStart method
-    dynThread = new Thread(dynHandler);
+    dynThread = null;
     //doesn't copy lance internal env-vars, just the docker ones
     //lance internal env-vars will be copied when an environment-variable changes a value and redeployment is triggered
     initRedeployDockerCommands();
@@ -179,6 +179,7 @@ public class DockerContainerLogic extends AbstractDockerContainerLogic {
           .getUpdateScriptFilePath(), client);
       dynHandler.setAccessor(accessor);
       //todo: check if must be initialised in doStart method
+      dynThread = new Thread(dynHandler);
       dynThread.start();
     } catch (DockerCommandException e) {
       throw new ContainerException("Cannot initialize Dyn Handler. Problems setting the correct container name...", e);
@@ -188,6 +189,11 @@ public class DockerContainerLogic extends AbstractDockerContainerLogic {
   @Override
   public void doStopDynHandling() throws ContainerException {
     dynHandler.setRunning(false);
+    try {
+      dynThread.join();
+    } catch (InterruptedException e) {
+      throw new ContainerException("Dyn Handling was interrupted while waiting for the handler thread to finish.");
+    }
   }
 
   @Override

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerContainerLogic.java
@@ -1,5 +1,6 @@
 package de.uniulm.omi.cloudiator.lance.lca.containers.docker;
 
+import de.uniulm.omi.cloudiator.lance.application.component.AbstractComponent;
 import de.uniulm.omi.cloudiator.lance.application.component.DockerComponent;
 import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
 import de.uniulm.omi.cloudiator.lance.lca.container.environment.BashExportBasedVisitor;
@@ -139,6 +140,22 @@ public class DockerContainerLogic extends AbstractDockerContainerLogic {
     } catch(DockerCommandException ce) {
       throw new ContainerException(ce);
     }
+  }
+
+  @Override
+  public AbstractComponent getComponent() {
+    return myComponent;
+  }
+
+  @Override
+  public boolean isValidDynamicProperty(String key) {
+    if(key.equals(myComponent.dynGroupKey)) {
+      return true;
+    } else if(key.equals(myComponent.dynHandlerKey))  {
+      return true;
+    }
+
+    return false;
   }
 
   @Override

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerContainerLogic.java
@@ -36,6 +36,7 @@ public class DockerContainerLogic extends AbstractDockerContainerLogic {
   //Needed to check for redeployment
   private Map<String, String> envVarsDynamicPrev;
   private DockerDynHandler dynHandler;
+  private Thread dynThread;
 
   private enum EnvType {STATIC, DYNAMIC};
 
@@ -54,6 +55,8 @@ public class DockerContainerLogic extends AbstractDockerContainerLogic {
     envVarsDynamicPrev = new HashMap<>(envVarsDynamic);
     //Getting initialized dynamically
     dynHandler = null;
+    //todo: check if must be initialised in doStart method
+    dynThread = new Thread(dynHandler);
     //doesn't copy lance internal env-vars, just the docker ones
     //lance internal env-vars will be copied when an environment-variable changes a value and redeployment is triggered
     initRedeployDockerCommands();
@@ -175,7 +178,8 @@ public class DockerContainerLogic extends AbstractDockerContainerLogic {
       dynHandler = new DockerDynHandler(myComponent.getContainerName(), myComponent.getDynamicHandler(), myComponent
           .getUpdateScriptFilePath(), client);
       dynHandler.setAccessor(accessor);
-      dynHandler.run();
+      //todo: check if must be initialised in doStart method
+      dynThread.start();
     } catch (DockerCommandException e) {
       throw new ContainerException("Cannot initialize Dyn Handler. Problems setting the correct container name...", e);
     }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerContainerLogic.java
@@ -1,7 +1,12 @@
 package de.uniulm.omi.cloudiator.lance.lca.containers.docker;
 
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.COMPONENT_INSTANCE_STATUS;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.DYN_GROUP_KEY;
+import static de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers.DYN_HANDLER_KEY;
+
 import de.uniulm.omi.cloudiator.lance.application.component.AbstractComponent;
 import de.uniulm.omi.cloudiator.lance.application.component.DockerComponent;
+import de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants;
 import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
 import de.uniulm.omi.cloudiator.lance.lca.container.environment.BashExportBasedVisitor;
 import de.uniulm.omi.cloudiator.lance.lca.container.port.DownstreamAddress;
@@ -149,9 +154,11 @@ public class DockerContainerLogic extends AbstractDockerContainerLogic {
 
   @Override
   public boolean isValidDynamicProperty(String key) {
-    if(key.equals(myComponent.dynGroupKey)) {
+    if(key.equals(LcaRegistryConstants.regEntries.get(DYN_GROUP_KEY))) {
       return true;
-    } else if(key.equals(myComponent.dynHandlerKey))  {
+    } else if(key.equals(LcaRegistryConstants.regEntries.get(DYN_HANDLER_KEY))) {
+      return true;
+    } else if(key.equals(LcaRegistryConstants.regEntries.get(COMPONENT_INSTANCE_STATUS))) {
       return true;
     }
 

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerContainerLogic.java
@@ -159,6 +159,7 @@ public class DockerContainerLogic extends AbstractDockerContainerLogic {
     return myComponent;
   }
 
+  //todo: Put this check into DockerDynHandler
   @Override
   public boolean isValidDynamicProperty(String key) {
     if(key.equals(LcaRegistryConstants.regEntries.get(DYN_GROUP_KEY))) {

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerDynHandler.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerDynHandler.java
@@ -3,11 +3,13 @@ package de.uniulm.omi.cloudiator.lance.lca.containers.docker;
 import de.uniulm.omi.cloudiator.lance.lca.GlobalRegistryAccessor;
 import de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants;
 import de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers;
+import de.uniulm.omi.cloudiator.lance.lca.container.ComponentInstanceId;
 import de.uniulm.omi.cloudiator.lance.lca.container.port.PortRegistryTranslator;
 import de.uniulm.omi.cloudiator.lance.lca.containers.docker.connector.DockerConnector;
 import de.uniulm.omi.cloudiator.lance.lca.containers.docker.connector.DockerException;
 import de.uniulm.omi.cloudiator.lance.lca.registry.RegistrationException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -26,8 +28,8 @@ class DockerDynHandler extends Thread {
   private final String dynHandlerVal;
   private final String updateScriptFilePath;
   private final DockerConnector client;
-  private List<String> socketsBefore;
-  private List<String> socketsAfter;
+  private Map<ComponentInstanceId,String> socketsBefore;
+  private Map<ComponentInstanceId,String> socketsAfter;
   private GlobalRegistryAccessor accessor;
   private String containerName;
   private volatile boolean running;
@@ -37,8 +39,8 @@ class DockerDynHandler extends Thread {
     this.dynHandlerVal = dynHandlerVal;
     this.updateScriptFilePath = updateScriptFilePath;
     this.client = client;
-    socketsBefore = new ArrayList<>();
-    socketsAfter = new ArrayList<>();
+    socketsBefore = new HashMap<>();
+    socketsAfter = new HashMap<>();
     accessor = null;
     this.running = false;
   }
@@ -49,27 +51,31 @@ class DockerDynHandler extends Thread {
 
   @Override
   public void run() {
-    if(accessor==null) {
-      LOGGER.error("Docker Dyn Handler cannot start working as it cannot access the registry.");
-      return;
-    }
-
     this.running = true;
-    List<Map<String,String>> readyDumps = new ArrayList<>();
+    Map<ComponentInstanceId,Map<String,String>> readyDumps = new HashMap<>();
     LOGGER.info(String
         .format("Starting dynamic Handler: %s.", containerName));
 
     do {
       try {
+        if(accessor==null) {
+          LOGGER.error("Docker Dyn Handler cannot continue working as it cannot access the registry.");
+          return;
+        }
+
         readyDumps = accessor.getReadyDumps();
         socketsAfter = filterHandlerGroupSocks(readyDumps);
-        if(checkSocketsDiff()) {
-          final String execString = buildExecInsideContainerString(socketsAfter, updateScriptFilePath);
-          LOGGER.info(String
-              .format("Starting dynamic update via docker cli command: %s.", execString));
-          client.executeSingleDockerCommand(execString);
-          socketsBefore = socketsAfter;
+        final SocketsDiff socketsDiff = calcSocketsDiff();
+
+        if(socketsDiff.hasDiff()) {
+          executeUpdate();
         }
+
+        if(socketsDiff.hasDestroyed()) {
+          syncDestruction(socketsDiff.socketsDestroyed);
+        }
+
+        socketsBefore = socketsAfter;
       } catch (RegistrationException e) {
         LOGGER.error(String
             .format("Cannot access registry properly in Dyn Handler component."));
@@ -80,24 +86,79 @@ class DockerDynHandler extends Thread {
     } while (running);
   }
 
-  private boolean checkSocketsDiff() {
-    Set<String> before = new HashSet<>(socketsBefore);
-    Set<String> after = new HashSet<>(socketsAfter);
-
-    if(before.equals(after)) {
-      return false;
+  /* If a Dyn Component is about to be destroyed, it waits (thread.wait) for the DynHandler to execute the update
+  * accordingly AND syncing the Dyn Component's state to PRE_STOP in the registry before it can continue (i.e.
+  * breaking out of thread.wait)*/
+  private void syncDestruction(Map<ComponentInstanceId,String> destrSocks) throws RegistrationException {
+    for(Map.Entry<ComponentInstanceId,String> sock: destrSocks.entrySet()) {
+      LOGGER.warn(String
+          .format("Setting Dynamic Component Instance %s Container_Status to a temporally inconsistent state"
+              + " for synchronisation purposes.", sock.getKey()));
+      accessor.syncDynamicDestructionStatus(sock.getKey());
     }
-
-    return true;
   }
 
-  private List<String> filterHandlerGroupSocks(List<Map<String, String>> readyDumps) throws RegistrationException {
-    List<String> socks = new ArrayList<>();
+  private void executeUpdate() throws DockerException {
+    final String execString = buildExecInsideContainerString(socketsAfter, updateScriptFilePath);
+    LOGGER.info(String
+        .format("Starting dynamic update via docker cli command: %s.", execString));
+    client.executeSingleDockerCommand(execString);
+  }
+
+  private SocketsDiff calcSocketsDiff() {
+    Map<ComponentInstanceId, String> socketsKept = new HashMap<>();
+    Map<ComponentInstanceId, String> socketsNew = new HashMap<>();
+    Map<ComponentInstanceId, String> socketsDestroyed = new HashMap<>();
+
+    for (Map.Entry<ComponentInstanceId, String> socketBefore : socketsBefore.entrySet()) {
+      boolean found = false;
+      final String beforeKey = socketBefore.getKey().toString();
+      final String beforeVal = socketBefore.getValue();
+      //todo: use map.get instead of 2nd loop
+      for (Map.Entry<ComponentInstanceId, String> socketAfter : socketsAfter.entrySet()) {
+        final String afterKey = socketAfter.getKey().toString();
+        final String afterVal = socketAfter.getValue();
+
+        if (beforeKey.equals(afterKey) && beforeVal.equals(afterVal)) {
+          socketsKept.put(socketBefore.getKey(),socketBefore.getValue());
+          found = true;
+        }
+      }
+
+      if(found==false) {
+        socketsDestroyed.put(socketBefore.getKey(),socketBefore.getValue());
+      }
+    }
+
+    for (Map.Entry<ComponentInstanceId, String> socketAfter : socketsAfter.entrySet()) {
+      final String keptSocket = socketsKept.get(socketAfter.getKey());
+      if( keptSocket != null && keptSocket.equals(socketAfter.getValue())) {
+        continue;
+      }
+      socketsNew.put(socketAfter.getKey(), socketAfter.getValue());
+    }
+
+    SocketsDiff diff = new SocketsDiff();
+    diff.socketsKept = socketsKept;
+    diff.socketsNew = socketsNew;
+    diff.socketsDestroyed = socketsDestroyed;
+
+    return diff;
+  }
+
+  private Map<ComponentInstanceId, String> filterHandlerGroupSocks(Map<ComponentInstanceId,Map<String, String>> readyDumps) throws RegistrationException {
+    Map<ComponentInstanceId, String> socks = new HashMap<>();
     final String dynGroupKey = LcaRegistryConstants.regEntries.get(Identifiers.DYN_GROUP_KEY);
-    for(Map<String,String> compDump: readyDumps) {
-      String dynGroupVal = compDump.get(dynGroupKey);
-      if(dynGroupVal != null && dynGroupVal.equals(dynHandlerVal)) {
-        socks.add(buildSocket(compDump));
+
+    for(Map.Entry<ComponentInstanceId,Map<String,String>> compDump: readyDumps.entrySet()) {
+      if(compDump.getValue() == null || compDump.getValue().get(dynGroupKey) == null) {
+        continue;
+      }
+
+      Map<String,String> dumpMap = compDump.getValue();
+      String dynGroupVal = dumpMap.get(dynGroupKey);
+      if(dynGroupVal.equals(dynHandlerVal)) {
+        socks.put(compDump.getKey(), buildSocket(dumpMap));
       }
     }
 
@@ -105,10 +166,11 @@ class DockerDynHandler extends Thread {
   }
 
   private String buildExecInsideContainerString(
-      List<String> sockets, String updateScriptFilePath) {
+      Map<ComponentInstanceId,String> sockets, String updateScriptFilePath) {
 
     StringBuilder sb = new StringBuilder();
-    for (String s : sockets) {
+    for (Map.Entry<ComponentInstanceId,String> entry : sockets.entrySet()) {
+      final String s = entry.getValue();
       sb.append(s);
       sb.append(" ");
     }
@@ -151,5 +213,31 @@ class DockerDynHandler extends Thread {
 
   public boolean isRunning() {
     return running;
+  }
+
+  /* Provides info about the diff in the available sockets */
+  private static class SocketsDiff {
+    public Map<ComponentInstanceId,String> socketsKept;
+    public Map<ComponentInstanceId,String> socketsNew;
+    public Map<ComponentInstanceId,String> socketsDestroyed;
+
+    private SocketsDiff() {
+      socketsKept = new HashMap<>();
+      socketsNew = new HashMap<>();
+      socketsDestroyed = new HashMap<>();
+    }
+
+    /* Did smth change between two iterations? */
+    private boolean hasDiff() {
+      if(socketsDestroyed.size()==0 && socketsNew.size()==0) {
+        return false;
+      }
+
+      return true;
+    }
+
+    private boolean hasDestroyed() {
+      return (socketsDestroyed.size() > 0) ? true : false;
+    }
   }
 }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerDynHandler.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerDynHandler.java
@@ -158,7 +158,7 @@ class DockerDynHandler extends Thread {
       Map<String,String> dumpMap = compDump.getValue();
       String dynGroupVal = dumpMap.get(dynGroupKey);
       if(dynGroupVal.equals(dynHandlerVal)) {
-        socks.put(compDump.getKey(), buildSocket(dumpMap));
+        socks.put(compDump.getKey(), buildSocket(dumpMap, containerName));
       }
     }
 
@@ -182,11 +182,18 @@ class DockerDynHandler extends Thread {
     return commandStr;
   }
 
-  private static String buildSocket(Map<String, String> compDump) throws RegistrationException {
+  private static String buildSocket(Map<String, String> compDump, String cName) throws RegistrationException {
     final String ipVal = PortRegistryTranslator.getHierarchicalHostname(PortRegistryTranslator.PORT_HIERARCHY_0, compDump);
     final String portVal = getPortVal(compDump);
-    final String socket = ipVal + ":" + portVal;
-    
+    String socket = "";
+    if(portVal.equals("-1")) {
+      LOGGER.warn(String
+          .format("Found port value -1 for a socket in Dynamic Handler %s. Skipping it"
+              + "...", cName));
+    } else {
+      socket = ipVal + ":" + portVal;
+    }
+
     return socket;
   }
 
@@ -195,6 +202,9 @@ class DockerDynHandler extends Thread {
     for(Map.Entry<String,String> entry: compDump.entrySet()) {
       final String key = entry.getKey();
       if(key.matches("^[^\\s]*PUBLIC[^\\s]+Port$")) {
+        retVal = entry.getValue();
+      }
+      if(key.matches("^[^\\s]*PUBLIC[^\\s]+I[Nn][Pp]$")) {
         retVal = entry.getValue();
       }
     }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerDynHandler.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerDynHandler.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 /* Executes a script inside the container, that processes the 'ip:port'
 vaLues of associated dyngroup components inside the registry */
-class DockerDynHandler implements Runnable {
+class DockerDynHandler extends Thread {
   private static final Logger LOGGER = LoggerFactory.getLogger(DockerContainerManager.class);
 
   private final String dynHandlerVal;
@@ -56,6 +56,8 @@ class DockerDynHandler implements Runnable {
 
     this.running = true;
     List<Map<String,String>> readyDumps = new ArrayList<>();
+    LOGGER.info(String
+        .format("Starting dynamic Handler: %s.", containerName));
 
     do {
       try {
@@ -94,7 +96,7 @@ class DockerDynHandler implements Runnable {
     final String dynGroupKey = LcaRegistryConstants.regEntries.get(Identifiers.DYN_GROUP_KEY);
     for(Map<String,String> compDump: readyDumps) {
       String dynGroupVal = compDump.get(dynGroupKey);
-      if(dynGroupVal==dynHandlerVal) {
+      if(dynGroupVal != null && dynGroupVal.equals(dynHandlerVal)) {
         socks.add(buildSocket(compDump));
       }
     }
@@ -112,8 +114,8 @@ class DockerDynHandler implements Runnable {
     }
 
     final String socketsStr = sb.toString();
-    final String commandStr = "exec -ti " + containerName + " " + updateScriptFilePath
-        + " " + updateScriptFilePath;
+    final String commandStr = "exec -ti " + containerName + " " + updateScriptFilePath + " "
+        + socketsStr;
 
     return commandStr;
   }

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerDynHandler.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerDynHandler.java
@@ -52,7 +52,7 @@ class DockerDynHandler extends Thread {
   @Override
   public void run() {
     this.running = true;
-    Map<ComponentInstanceId,Map<String,String>> readyDumps = new HashMap<>();
+    Map<ComponentInstanceId,Map<String,String>> runningDumps = new HashMap<>();
     LOGGER.info(String
         .format("Starting dynamic Handler: %s.", containerName));
 
@@ -63,8 +63,8 @@ class DockerDynHandler extends Thread {
           return;
         }
 
-        readyDumps = accessor.getReadyDumps();
-        socketsAfter = filterHandlerGroupSocks(readyDumps);
+        runningDumps = accessor.getRunningDumps();
+        socketsAfter = filterHandlerGroupSocks(runningDumps);
         final SocketsDiff socketsDiff = calcSocketsDiff();
 
         if(socketsDiff.hasDiff()) {

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerDynHandler.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/DockerDynHandler.java
@@ -1,0 +1,153 @@
+package de.uniulm.omi.cloudiator.lance.lca.containers.docker;
+
+import de.uniulm.omi.cloudiator.lance.lca.GlobalRegistryAccessor;
+import de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants;
+import de.uniulm.omi.cloudiator.lance.lca.LcaRegistryConstants.Identifiers;
+import de.uniulm.omi.cloudiator.lance.lca.container.port.PortRegistryTranslator;
+import de.uniulm.omi.cloudiator.lance.lca.containers.docker.connector.DockerConnector;
+import de.uniulm.omi.cloudiator.lance.lca.containers.docker.connector.DockerException;
+import de.uniulm.omi.cloudiator.lance.lca.registry.RegistrationException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+//Todo: Handle sockets inside of Set
+
+/* Executes a script inside the container, that processes the 'ip:port'
+vaLues of associated dyngroup components inside the registry */
+class DockerDynHandler implements Runnable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DockerContainerManager.class);
+
+  private final String dynHandlerVal;
+  private final String updateScriptFilePath;
+  private final DockerConnector client;
+  private List<String> socketsBefore;
+  private List<String> socketsAfter;
+  private GlobalRegistryAccessor accessor;
+  private String containerName;
+  private volatile boolean running;
+
+  DockerDynHandler(String containerName, String dynHandlerVal, String updateScriptFilePath, DockerConnector client) {
+    this.containerName = containerName;
+    this.dynHandlerVal = dynHandlerVal;
+    this.updateScriptFilePath = updateScriptFilePath;
+    this.client = client;
+    socketsBefore = new ArrayList<>();
+    socketsAfter = new ArrayList<>();
+    accessor = null;
+    this.running = false;
+  }
+
+  public void setAccessor(GlobalRegistryAccessor accessor) {
+    this.accessor = accessor;
+  }
+
+  @Override
+  public void run() {
+    if(accessor==null) {
+      LOGGER.error("Docker Dyn Handler cannot start working as it cannot access the registry.");
+      return;
+    }
+
+    this.running = true;
+    List<Map<String,String>> readyDumps = new ArrayList<>();
+
+    do {
+      try {
+        readyDumps = accessor.getReadyDumps();
+        socketsAfter = filterHandlerGroupSocks(readyDumps);
+        if(checkSocketsDiff()) {
+          final String execString = buildExecInsideContainerString(socketsAfter, updateScriptFilePath);
+          LOGGER.info(String
+              .format("Starting dynamic update via docker cli command: %s.", execString));
+          client.executeSingleDockerCommand(execString);
+          socketsBefore = socketsAfter;
+        }
+      } catch (RegistrationException e) {
+        LOGGER.error(String
+            .format("Cannot access registry properly in Dyn Handler component."));
+      } catch (DockerException e) {
+        LOGGER.error(String
+            .format("Cannot execute dynamic update inside Dyn Handler container: %s.", containerName));
+      }
+    } while (running);
+  }
+
+  private boolean checkSocketsDiff() {
+    Set<String> before = new HashSet<>(socketsBefore);
+    Set<String> after = new HashSet<>(socketsAfter);
+
+    if(before.equals(after)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private List<String> filterHandlerGroupSocks(List<Map<String, String>> readyDumps) throws RegistrationException {
+    List<String> socks = new ArrayList<>();
+    final String dynGroupKey = LcaRegistryConstants.regEntries.get(Identifiers.DYN_GROUP_KEY);
+    for(Map<String,String> compDump: readyDumps) {
+      String dynGroupVal = compDump.get(dynGroupKey);
+      if(dynGroupVal==dynHandlerVal) {
+        socks.add(buildSocket(compDump));
+      }
+    }
+
+    return socks;
+  }
+
+  private String buildExecInsideContainerString(
+      List<String> sockets, String updateScriptFilePath) {
+
+    StringBuilder sb = new StringBuilder();
+    for (String s : sockets) {
+      sb.append(s);
+      sb.append(" ");
+    }
+
+    final String socketsStr = sb.toString();
+    final String commandStr = "exec -ti " + containerName + " " + updateScriptFilePath
+        + " " + updateScriptFilePath;
+
+    return commandStr;
+  }
+
+  private static String buildSocket(Map<String, String> compDump) throws RegistrationException {
+    final String ipVal = PortRegistryTranslator.getHierarchicalHostname(PortRegistryTranslator.PORT_HIERARCHY_0, compDump);
+    final String portVal = getPortVal(compDump);
+    final String socket = ipVal + ":" + portVal;
+    
+    return socket;
+  }
+
+  private static String getPortVal(Map<String, String> compDump) throws RegistrationException {
+    String retVal = "";
+    for(Map.Entry<String,String> entry: compDump.entrySet()) {
+      final String key = entry.getKey();
+      if(key.matches("^[^\\s]*PUBLIC[^\\s]+Port$")) {
+        retVal = entry.getValue();
+      }
+    }
+
+    if(retVal.equals("")) {
+      throw new RegistrationException("Dynamic Component has no public port set.");
+    }
+    return retVal;
+  }
+
+  //todo: better get this String from PortRegistryTranslator
+
+  public synchronized void setRunning(boolean running) {
+    this.running = running;
+  }
+
+  public boolean isRunning() {
+    return running;
+  }
+}

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/LifecycleDockerContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/LifecycleDockerContainerLogic.java
@@ -1,5 +1,6 @@
 package de.uniulm.omi.cloudiator.lance.lca.containers.docker;
 
+import de.uniulm.omi.cloudiator.lance.application.component.AbstractComponent;
 import de.uniulm.omi.cloudiator.lance.application.component.DeployableComponent;
 import de.uniulm.omi.cloudiator.lance.container.spec.os.OperatingSystem;
 import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
@@ -78,6 +79,17 @@ public class LifecycleDockerContainerLogic extends AbstractDockerContainerLogic 
   void collectDynamicEnvVars() {
     envVarsDynamic.putAll(myComponent.getEnvVars());
     envVarsDynamic.putAll(networkHandler.getEnvVars());
+  }
+
+  @Override
+  public AbstractComponent getComponent() {
+    return myComponent;
+  }
+
+  //No dynamic properties settable for LifecycleComponents
+  @Override
+  public boolean isValidDynamicProperty(String key) {
+    return false;
   }
 
   String getFullImageName() {

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/LifecycleDockerContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/docker/LifecycleDockerContainerLogic.java
@@ -3,6 +3,7 @@ package de.uniulm.omi.cloudiator.lance.lca.containers.docker;
 import de.uniulm.omi.cloudiator.lance.application.component.AbstractComponent;
 import de.uniulm.omi.cloudiator.lance.application.component.DeployableComponent;
 import de.uniulm.omi.cloudiator.lance.container.spec.os.OperatingSystem;
+import de.uniulm.omi.cloudiator.lance.lca.GlobalRegistryAccessor;
 import de.uniulm.omi.cloudiator.lance.lca.container.ContainerException;
 import de.uniulm.omi.cloudiator.lance.lca.container.environment.BashExportBasedVisitor;
 import de.uniulm.omi.cloudiator.lance.lca.container.port.DownstreamAddress;
@@ -90,6 +91,16 @@ public class LifecycleDockerContainerLogic extends AbstractDockerContainerLogic 
   @Override
   public boolean isValidDynamicProperty(String key) {
     return false;
+  }
+
+  @Override
+  public void doStartDynHandling(GlobalRegistryAccessor accessor) throws ContainerException {
+    throw new ContainerException("No dynamic handling possible for LifecycleDockerContainer");
+  }
+
+  @Override
+  public void doStopDynHandling() throws ContainerException {
+    throw new ContainerException("No dynamic handling possible for LifecycleDockerContainer");
   }
 
   String getFullImageName() {

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/plain/PlainContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/plain/PlainContainerLogic.java
@@ -159,6 +159,17 @@ public class PlainContainerLogic implements ContainerLogic, LifecycleActionInter
     });
   }
 
+  @Override
+  public AbstractComponent getComponent() {
+    return deployableComponent;
+  }
+
+  //No dynamic properties settable for Plain-Container
+  @Override
+  public boolean isValidDynamicProperty(String key) {
+    return false;
+  }
+
   PlainShell setDynamicEnvironment(PortDiff<DownstreamAddress> diff) throws ContainerException {
     this.deployableComponent.injectDeploymentContext(this.deploymentContext);
     networkHandler.generateDynamicEnvVars(diff);

--- a/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/plain/PlainContainerLogic.java
+++ b/server/src/main/java/de/uniulm/omi/cloudiator/lance/lca/containers/plain/PlainContainerLogic.java
@@ -24,6 +24,7 @@ import de.uniulm.omi.cloudiator.lance.application.component.InPort;
 import de.uniulm.omi.cloudiator.lance.container.spec.os.OperatingSystem;
 import de.uniulm.omi.cloudiator.lance.container.spec.os.OperatingSystemFamily;
 import de.uniulm.omi.cloudiator.lance.container.standard.ContainerLogic;
+import de.uniulm.omi.cloudiator.lance.lca.GlobalRegistryAccessor;
 import de.uniulm.omi.cloudiator.lance.lca.container.environment.StaticEnvVars;
 import de.uniulm.omi.cloudiator.lance.lca.HostContext;
 import de.uniulm.omi.cloudiator.lance.lca.container.ComponentInstanceId;
@@ -168,6 +169,16 @@ public class PlainContainerLogic implements ContainerLogic, LifecycleActionInter
   @Override
   public boolean isValidDynamicProperty(String key) {
     return false;
+  }
+
+  @Override
+  public void doStartDynHandling(GlobalRegistryAccessor accessor) throws ContainerException {
+    throw new ContainerException("No dynamic handling possible for PlainContainer");
+  }
+
+  @Override
+  public void doStopDynHandling() throws ContainerException {
+    throw new ContainerException("No dynamic handling possible for LifecycleDockerContainer");
   }
 
   PlainShell setDynamicEnvironment(PortDiff<DownstreamAddress> diff) throws ContainerException {

--- a/server/src/test/de/uniulm/omi/cloudiator/lance/lca/containers/dummy/DummyContainer.java
+++ b/server/src/test/de/uniulm/omi/cloudiator/lance/lca/containers/dummy/DummyContainer.java
@@ -1,5 +1,6 @@
 package de.uniulm.omi.cloudiator.lance.lca.containers.dummy;
 
+import de.uniulm.omi.cloudiator.lance.application.component.AbstractComponent;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -87,7 +88,17 @@ public class DummyContainer implements ContainerLogic {
         });
 	}
 
-	public void setStaticEnvironment() throws ContainerException {
+  @Override
+  public AbstractComponent getComponent() {
+    return null;
+  }
+
+  @Override
+  public boolean isValidDynamicProperty(String key) {
+    return false;
+  }
+
+  public void setStaticEnvironment() throws ContainerException {
 
 	}
 


### PR DESCRIPTION
* Gave option to a Docker Component to act as a dynamic handler
* Gave option to a Docker Component to publish itself as a dynamic  component in registry
* Based on running/not-running status of dynamic component in registry, handler can execute a script inside its  docker-container via: "/path/to/script.sh pub_ip_running1:port pub_ip_running2:port ..."
* Implemented logic to synchronize the statesduring destruction of the container:
I.e. the dynamic handler must register the destruction of a dynamic component before it gets eventually destroyed